### PR TITLE
[1차 MVP] 리크루팅 홈, 계획하기, 서류평가하기(평가전) 완료

### DIFF
--- a/src/main/java/com/cluting/clutingbackend/admininvite/controller/AdminInviteController.java
+++ b/src/main/java/com/cluting/clutingbackend/admininvite/controller/AdminInviteController.java
@@ -1,11 +1,57 @@
 package com.cluting.clutingbackend.admininvite.controller;
 
+import com.cluting.clutingbackend.admininvite.dto.AdminInviteAcceptRequestDto;
+import com.cluting.clutingbackend.admininvite.dto.AdminInviteRequestDto;
+import com.cluting.clutingbackend.admininvite.dto.AdminInviteResponseDto;
 import com.cluting.clutingbackend.admininvite.service.AdminInviteService;
+import com.cluting.clutingbackend.club.domain.Club;
+import com.cluting.clutingbackend.club.repository.ClubRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "[리크루팅 홈] 운영진 초대", description = "운영진 초대 관련 API")
 @RestController
+@RequestMapping("/api/v1/admin/invite")
 @RequiredArgsConstructor
 public class AdminInviteController {
     private final AdminInviteService adminInviteService;
+    private final ClubRepository clubRepository;
+
+    // [운영진 초대] 초대 링크 생성
+    @Operation(
+            summary = "초대 링크 생성",
+            description = "클럽 ID를 기반으로 운영진 초대 링크를 생성합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "초대 링크가 성공적으로 생성되었습니다."),
+                    @ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.")
+            }
+    )
+    @PostMapping
+    public ResponseEntity<String> generateInviteLink(@RequestBody AdminInviteRequestDto requestDto) {
+        Club club = clubRepository.findById(requestDto.getClubId())
+                .orElseThrow(() -> new IllegalArgumentException("Club not found"));
+        String link = adminInviteService.generateInviteLink(requestDto, club);
+        return ResponseEntity.ok(link);
+    }
+
+    // [운영진 초대] 초대 수락
+    @Operation(
+            summary = "초대 링크 수락",
+            description = "초대 링크를 통해 운영진으로 추가합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "운영진으로 성공적으로 추가되었습니다."),
+                    @ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.")
+            }
+    )
+    @PostMapping("/accept")
+    public ResponseEntity<AdminInviteResponseDto> acceptInvite(@RequestBody AdminInviteAcceptRequestDto requestDto) {
+        AdminInviteResponseDto responseDto = adminInviteService.acceptInvite(requestDto);
+        return ResponseEntity.ok(responseDto);
+    }
 }

--- a/src/main/java/com/cluting/clutingbackend/admininvite/domain/AdminInvite.java
+++ b/src/main/java/com/cluting/clutingbackend/admininvite/domain/AdminInvite.java
@@ -8,6 +8,7 @@ import java.time.LocalDateTime;
 
 @Entity
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)

--- a/src/main/java/com/cluting/clutingbackend/admininvite/domain/TempUser.java
+++ b/src/main/java/com/cluting/clutingbackend/admininvite/domain/TempUser.java
@@ -1,0 +1,27 @@
+package com.cluting.clutingbackend.admininvite.domain;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Entity
+// [운영진 초대] 비회원 유저 운영진 초대 시, 비회원 정보를 저장하기 위한 엔티티
+public class TempUser {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String email;
+
+    @OneToOne
+    private AdminInvite invite;
+
+    @Builder
+    public TempUser(String email, AdminInvite invite) {
+        this.email = email;
+        this.invite = invite;
+    }
+}

--- a/src/main/java/com/cluting/clutingbackend/admininvite/dto/AdminInviteAcceptRequestDto.java
+++ b/src/main/java/com/cluting/clutingbackend/admininvite/dto/AdminInviteAcceptRequestDto.java
@@ -1,0 +1,12 @@
+package com.cluting.clutingbackend.admininvite.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+// [운영진 초대] 초대 수락 시, 토큰과 이메일을 통해 운영진 수락됨.
+@Getter
+@Setter
+public class AdminInviteAcceptRequestDto {
+    private String token;
+    private String email;
+}

--- a/src/main/java/com/cluting/clutingbackend/admininvite/dto/AdminInviteRequestDto.java
+++ b/src/main/java/com/cluting/clutingbackend/admininvite/dto/AdminInviteRequestDto.java
@@ -1,0 +1,11 @@
+package com.cluting.clutingbackend.admininvite.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+// [운영진 초대] 초대 링크 생성 시, clubId를 기반으로 토큰을 생성함.
+@Getter
+@Setter
+public class AdminInviteRequestDto {
+    private Long clubId;
+}

--- a/src/main/java/com/cluting/clutingbackend/admininvite/dto/AdminInviteResponseDto.java
+++ b/src/main/java/com/cluting/clutingbackend/admininvite/dto/AdminInviteResponseDto.java
@@ -1,0 +1,12 @@
+package com.cluting.clutingbackend.admininvite.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+// [운영진 초대] 초대 수락 시, 동아리 이름과 기수를 보여줌.
+@Getter
+@AllArgsConstructor
+public class AdminInviteResponseDto {
+    private String clubName;
+    private Integer generation;
+}

--- a/src/main/java/com/cluting/clutingbackend/admininvite/repository/AdminInviteRepository.java
+++ b/src/main/java/com/cluting/clutingbackend/admininvite/repository/AdminInviteRepository.java
@@ -4,6 +4,10 @@ import com.cluting.clutingbackend.admininvite.domain.AdminInvite;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface AdminInviteRepository extends JpaRepository<AdminInvite, Long> {
+    // [운영진 초대] 토큰으로 초대 정보 찾기
+    Optional<AdminInvite> findByUniqueInviteToken(String token);
 }

--- a/src/main/java/com/cluting/clutingbackend/admininvite/repository/TempUserRepository.java
+++ b/src/main/java/com/cluting/clutingbackend/admininvite/repository/TempUserRepository.java
@@ -1,0 +1,10 @@
+package com.cluting.clutingbackend.admininvite.repository;
+
+import com.cluting.clutingbackend.admininvite.domain.TempUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface TempUserRepository extends JpaRepository<TempUser, Long> {
+    Optional<TempUser> findByEmail(String email);
+}

--- a/src/main/java/com/cluting/clutingbackend/admininvite/service/AdminInviteService.java
+++ b/src/main/java/com/cluting/clutingbackend/admininvite/service/AdminInviteService.java
@@ -1,11 +1,97 @@
 package com.cluting.clutingbackend.admininvite.service;
 
+import com.cluting.clutingbackend.admininvite.domain.AdminInvite;
+import com.cluting.clutingbackend.admininvite.domain.TempUser;
+import com.cluting.clutingbackend.admininvite.dto.AdminInviteAcceptRequestDto;
+import com.cluting.clutingbackend.admininvite.dto.AdminInviteRequestDto;
+import com.cluting.clutingbackend.admininvite.dto.AdminInviteResponseDto;
 import com.cluting.clutingbackend.admininvite.repository.AdminInviteRepository;
+import com.cluting.clutingbackend.admininvite.repository.TempUserRepository;
+import com.cluting.clutingbackend.club.domain.Club;
+import com.cluting.clutingbackend.clubuser.domain.ClubUser;
+import com.cluting.clutingbackend.clubuser.repository.ClubUserRepository;
+import com.cluting.clutingbackend.global.enums.ClubRole;
+import com.cluting.clutingbackend.recruit.domain.Recruit;
+import com.cluting.clutingbackend.user.domain.User;
+import com.cluting.clutingbackend.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 public class AdminInviteService {
     private final AdminInviteRepository adminInviteRepository;
+    private final UserRepository userRepository;
+    private final TempUserRepository tempUserRepository;
+    private final ClubUserRepository clubUserRepository;
+
+    // [운영진 초대] 초대 링크 생성
+    @Transactional
+    public String generateInviteLink(AdminInviteRequestDto requestDto, Club club) {
+        String token = UUID.randomUUID().toString();
+        AdminInvite adminInvite = AdminInvite.builder()
+                .uniqueInviteToken(token)
+                .club(club)
+                .expirationDate(LocalDateTime.now().plusDays(7))
+                .isUsed(false)
+                .build();
+        adminInviteRepository.save(adminInvite);
+
+        String baseUrl = ServletUriComponentsBuilder.fromCurrentContextPath().toUriString();
+        return baseUrl + "/api/v1/admin/invite?token=" + token;
+    }
+
+    // [운영진 초대] 초대 수락(회원/비회원에 따라 로직이 달라짐)
+    @Transactional
+    public AdminInviteResponseDto acceptInvite(AdminInviteAcceptRequestDto requestDto) {
+        AdminInvite adminInvite = adminInviteRepository.findByUniqueInviteToken(requestDto.getToken())
+                .orElseThrow(() -> new IllegalArgumentException("만료된 토큰이거나 유효하지 않은 토큰"));
+
+        if (adminInvite.getIsUsed() || adminInvite.getExpirationDate().isBefore(LocalDateTime.now())) {
+            throw new IllegalArgumentException("만료된 토큰이거나 이미 사용된 토큰");
+        }
+
+        // 회원인지, 비회원인지
+        User user = userRepository.findByEmail(requestDto.getEmail())
+                .orElseGet(() -> handleTemporaryUser(requestDto, adminInvite)); // 비회원일 때
+
+        Club club = adminInvite.getClub();
+        System.out.println("@@club : "+club.getName());
+
+        // 기수 가져오기
+        Recruit recruit = club.getRecruits().stream()
+                .filter(r -> !r.getIsDone())  //현재 활성화된 공고만
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("모집 공고를 찾지 못함"));
+
+        ClubUser clubUser = ClubUser.builder()
+                .user(user)
+                .club(club)
+                .role(ClubRole.STAFF)
+                .generation(recruit.getGeneration())
+                .build();
+        clubUserRepository.save(clubUser);
+
+        // 토큰 만료 상태로 변경
+        adminInvite.setIsUsed(true);
+        adminInviteRepository.save(adminInvite);
+
+        return new AdminInviteResponseDto(club.getName(), recruit.getGeneration());
+    }
+
+    // [운영진 초대] 비회원 로직 처리
+    private User handleTemporaryUser(AdminInviteAcceptRequestDto requestDto, AdminInvite adminInvite) {
+        TempUser tempUser = TempUser.builder()
+                .email(requestDto.getEmail())
+                .invite(adminInvite)
+                .build();
+        tempUserRepository.save(tempUser);
+
+        throw new IllegalArgumentException("비회원. 회원가입 페이지로 다이렉트 바람.");
+    }
 }

--- a/src/main/java/com/cluting/clutingbackend/application/domain/Application.java
+++ b/src/main/java/com/cluting/clutingbackend/application/domain/Application.java
@@ -1,6 +1,5 @@
 package com.cluting.clutingbackend.application.domain;
 
-import com.cluting.clutingbackend.clubuser.domain.ClubUser;
 import com.cluting.clutingbackend.recruit.domain.Recruit;
 import com.cluting.clutingbackend.user.domain.User;
 import com.cluting.clutingbackend.global.enums.EvaluateStatus;
@@ -40,7 +39,7 @@ public class Application {
     private Recruit recruit;
 
     @Column(length = 100, nullable = true)
-    private String part; // 직렬화, 역직렬화 필요
+    private String recruit_group; // 직렬화, 역직렬화 필요
 
     @Column
     @CreatedDate

--- a/src/main/java/com/cluting/clutingbackend/application/repository/ApplicationRepository.java
+++ b/src/main/java/com/cluting/clutingbackend/application/repository/ApplicationRepository.java
@@ -4,6 +4,10 @@ import com.cluting.clutingbackend.application.domain.Application;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface ApplicationRepository extends JpaRepository<Application, Long> {
+    // [서류 평가하기] 해당 모집공고에 지원한 지원서 불러오기
+    List<Application> findByRecruitId(Long recruitId);
 }

--- a/src/main/java/com/cluting/clutingbackend/clubuser/repository/ClubUserRepository.java
+++ b/src/main/java/com/cluting/clutingbackend/clubuser/repository/ClubUserRepository.java
@@ -3,6 +3,7 @@ package com.cluting.clutingbackend.clubuser.repository;
 import com.cluting.clutingbackend.clubuser.domain.ClubUser;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -23,4 +24,16 @@ public interface ClubUserRepository extends JpaRepository<ClubUser, Long> {
     // [리크루팅 홈] 해당 운영진 정보 가져오기
     @Query("SELECT cu FROM ClubUser cu WHERE cu.club.id = :clubId AND cu.user.id = :clubUserId")
     ClubUser findByClubIdAndUserId(Long clubId, Long clubUserId);
+
+    // [계획하기] 운영진 리스트 불러오기
+    @Query("""
+    SELECT u.name
+    FROM ClubUser cu
+    JOIN Recruit r ON cu.generation = r.generation
+    JOIN User u ON cu.user.id = u.id
+    WHERE r.id = :recruitId
+      AND cu.role = 'STAFF'
+    """)
+    List<String> findStaffNamesByRecruitId(@Param("recruitId") Long recruitId);
+
 }

--- a/src/main/java/com/cluting/clutingbackend/clubuser/repository/ClubUserRepository.java
+++ b/src/main/java/com/cluting/clutingbackend/clubuser/repository/ClubUserRepository.java
@@ -2,8 +2,25 @@ package com.cluting.clutingbackend.clubuser.repository;
 
 import com.cluting.clutingbackend.clubuser.domain.ClubUser;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface ClubUserRepository extends JpaRepository<ClubUser, Long> {
+    // [리크루팅 홈] 운영진 가져오기
+    @Query("""
+    SELECT cu\s
+    FROM ClubUser cu\s
+    JOIN Recruit r ON cu.club.id = r.club.id\s
+    WHERE cu.club.id = :clubId\s
+      AND cu.generation = r.generation\s
+      AND cu.role = 'STAFF'
+   \s""")
+    List<ClubUser> findStaffByClubIdAndGeneration(Long clubId);
+
+    // [리크루팅 홈] 해당 운영진 정보 가져오기
+    @Query("SELECT cu FROM ClubUser cu WHERE cu.club.id = :clubId AND cu.user.id = :clubUserId")
+    ClubUser findByClubIdAndUserId(Long clubId, Long clubUserId);
 }

--- a/src/main/java/com/cluting/clutingbackend/evaluation/controller/DocumentEvaluationController.java
+++ b/src/main/java/com/cluting/clutingbackend/evaluation/controller/DocumentEvaluationController.java
@@ -1,0 +1,77 @@
+package com.cluting.clutingbackend.evaluation.controller;
+
+import com.cluting.clutingbackend.evaluation.dto.DocumentEvaluationRequest;
+import com.cluting.clutingbackend.evaluation.dto.DocumentEvaluationResponse;
+import com.cluting.clutingbackend.evaluation.service.DocumentEvaluationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "[3. 서류 평가하기]", description = "서류 평가 관련 API")
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/eval/doc/{recruitId}")
+public class DocumentEvaluationController {
+
+    private final DocumentEvaluationService documentEvaluationService;
+
+    @Operation(
+            summary = "[서류 평가하기] 평가 전 상태인 지원서 리스트 불러오기(필터, 정렬 설정 안 한 초기 상태)",
+            description = "서류 평가가 완료되지 않은 평가 전 상태인 지원서 리스트를 반환합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "서류 평가 전 지원서 리스트 반환 성공"),
+                    @ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터"),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+            }
+    )
+    @GetMapping
+    public List<DocumentEvaluationResponse> getPendingEvaluations(@PathVariable Long recruitId) {
+        return documentEvaluationService.getPendingEvaluations(recruitId);
+    }
+
+    @Operation(
+            summary = "[서류 평가하기] 그룹별 지원서 리스트 불러오기",
+            description = "그룹별로 평가된 지원서를 반환합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "그룹별 지원서 리스트 반환 성공"),
+                    @ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터"),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+            }
+    )
+    @GetMapping("/group")
+    public List<DocumentEvaluationResponse> getDocumentsByGroup(@PathVariable Long recruitId, @RequestBody DocumentEvaluationRequest request) {
+        return documentEvaluationService.getDocumentsByGroup(recruitId, request.getGroupName());
+    }
+
+    @Operation(
+            summary = "[서류 평가하기] 최신순 지원서 리스트 불러오기",
+            description = "최신 지원서를 반환합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "최신 지원서 리스트 반환 성공"),
+                    @ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터"),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+            }
+    )
+    @GetMapping("/newest")
+    public List<DocumentEvaluationResponse> getDocumentsByNewest(@PathVariable Long recruitId) {
+        return documentEvaluationService.getDocumentsByNewest(recruitId);
+    }
+
+    @Operation(
+            summary = "[서류 평가하기] 지원서순 리스트 불러오기",
+            description = "오래된 지원서를 반환합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "오래된 지원서 리스트 반환 성공"),
+                    @ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터"),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+            }
+    )
+    @GetMapping("/oldest")
+    public List<DocumentEvaluationResponse> getDocumentsByOldest(@PathVariable Long recruitId) {
+        return documentEvaluationService.getDocumentsByOldest(recruitId);
+    }
+}

--- a/src/main/java/com/cluting/clutingbackend/evaluation/dto/DocumentEvaluationRequest.java
+++ b/src/main/java/com/cluting/clutingbackend/evaluation/dto/DocumentEvaluationRequest.java
@@ -1,0 +1,12 @@
+package com.cluting.clutingbackend.evaluation.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DocumentEvaluationRequest {
+    private String groupName;
+}

--- a/src/main/java/com/cluting/clutingbackend/evaluation/dto/DocumentEvaluationResponse.java
+++ b/src/main/java/com/cluting/clutingbackend/evaluation/dto/DocumentEvaluationResponse.java
@@ -1,0 +1,21 @@
+package com.cluting.clutingbackend.evaluation.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+// [서류 평가하기] 지원서 리스트
+@Getter
+@Setter
+@AllArgsConstructor
+public class DocumentEvaluationResponse {
+    private String evaluationStage;
+    private String applicantName;
+    private String applicantPhone;
+    private String groupName;
+    private String applicationNumClubUser;
+    private LocalDateTime createdAt;
+
+}

--- a/src/main/java/com/cluting/clutingbackend/evaluation/service/DocumentEvaluationService.java
+++ b/src/main/java/com/cluting/clutingbackend/evaluation/service/DocumentEvaluationService.java
@@ -1,0 +1,114 @@
+package com.cluting.clutingbackend.evaluation.service;
+
+import com.cluting.clutingbackend.application.domain.Application;
+import com.cluting.clutingbackend.application.repository.ApplicationRepository;
+import com.cluting.clutingbackend.evaluation.dto.DocumentEvaluationResponse;
+import com.cluting.clutingbackend.plan.domain.DocumentEvaluator;
+import com.cluting.clutingbackend.plan.domain.Group;
+import com.cluting.clutingbackend.plan.repository.DocumentEvaluatorRepository;
+import com.cluting.clutingbackend.recruit.repository.RecruitRepository;
+import com.cluting.clutingbackend.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Service
+public class DocumentEvaluationService {
+
+    private final ApplicationRepository applicationRepository;
+    private final DocumentEvaluatorRepository documentEvaluatorRepository;
+    private final RecruitRepository recruitRepository;
+
+    // 모집 공고가 존재하는지 확인
+    private void ensureRecruitExists(Long recruitId) {
+        if (!recruitRepository.existsById(recruitId)) {
+            throw new IllegalArgumentException("모집 공고가 존재하지 않습니다.");
+        }
+    }
+
+    // 문서 변환 메서드
+    private DocumentEvaluationResponse mapToResponse(Application application, Long recruitId) {
+        User user = application.getUser();
+
+        // 평가할 전체 운영진 수 가져오기
+        int totalEvaluableClubUsers = documentEvaluatorRepository.countUniqueClubUserIdsByRecruitIdAndApplicationId(recruitId, application.getId());
+
+        // 문서 평가자 정보 가져오기
+        DocumentEvaluator evaluator = documentEvaluatorRepository.findByApplicationId(application.getId());
+        Group group = evaluator != null ? evaluator.getGroup() : null;
+
+        return new DocumentEvaluationResponse(
+                evaluator != null ? evaluator.getStage().name() : null,
+                user.getName(),
+                user.getPhone(),
+                group != null ? group.getName() : null,
+                application.getNumClubUser() + "/" + totalEvaluableClubUsers, // 현재 평가한 운영진 수 / 평가할 전체 운영진 수
+                application.getCreatedAt() // createdAt 값 추가
+        );
+    }
+
+
+    // 평가 전 상태인 서류 평가 리스트 반환 (BEFORE인 상태만 필터링)
+    public List<DocumentEvaluationResponse> getPendingEvaluations(Long recruitId) {
+        ensureRecruitExists(recruitId);
+        List<Application> applications = applicationRepository.findByRecruitId(recruitId);
+
+        return applications.stream()
+                .filter(application -> {
+                    DocumentEvaluator evaluator = documentEvaluatorRepository.findByApplicationId(application.getId());
+                    return evaluator != null && evaluator.getStage().name().equals("BEFORE");
+                })
+                .map(application -> mapToResponse(application, recruitId))
+                .collect(Collectors.toList());
+    }
+
+    // 그룹별 서류 평가 리스트 반환 (BEFORE인 상태만 필터링)
+    public List<DocumentEvaluationResponse> getDocumentsByGroup(Long recruitId, String groupName) {
+        ensureRecruitExists(recruitId);
+        List<Application> applications = applicationRepository.findByRecruitId(recruitId);
+
+        return applications.stream()
+                .filter(application -> {
+                    DocumentEvaluator evaluator = documentEvaluatorRepository.findByApplicationId(application.getId());
+                    return evaluator != null && evaluator.getStage().name().equals("BEFORE") &&
+                            evaluator.getGroup() != null && evaluator.getGroup().getName().equals(groupName);
+                })
+                .map(application -> mapToResponse(application, recruitId))
+                .collect(Collectors.toList());
+    }
+
+    // 최신 서류 평가 리스트 반환 (BEFORE인 상태만 필터링)
+    public List<DocumentEvaluationResponse> getDocumentsByNewest(Long recruitId) {
+        ensureRecruitExists(recruitId);
+        List<Application> applications = applicationRepository.findByRecruitId(recruitId);
+
+        return applications.stream()
+                .filter(application -> {
+                    DocumentEvaluator evaluator = documentEvaluatorRepository.findByApplicationId(application.getId());
+                    return evaluator != null && evaluator.getStage().name().equals("BEFORE");
+                })
+                .map(application -> mapToResponse(application, recruitId)) // recruitId 전달
+                .sorted(Comparator.comparing(DocumentEvaluationResponse::getCreatedAt).reversed())
+                .collect(Collectors.toList());
+    }
+
+    // 오래된 서류 평가 리스트 반환 (BEFORE인 상태만 필터링)
+    public List<DocumentEvaluationResponse> getDocumentsByOldest(Long recruitId) {
+        ensureRecruitExists(recruitId);
+        List<Application> applications = applicationRepository.findByRecruitId(recruitId);
+
+        return applications.stream()
+                .filter(application -> {
+                    DocumentEvaluator evaluator = documentEvaluatorRepository.findByApplicationId(application.getId());
+                    return evaluator != null && evaluator.getStage().name().equals("BEFORE");
+                })
+                .map(application -> mapToResponse(application, recruitId)) // recruitId 전달
+                .sorted(Comparator.comparing(DocumentEvaluationResponse::getCreatedAt))
+                .collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/com/cluting/clutingbackend/interview/domain/Interview.java
+++ b/src/main/java/com/cluting/clutingbackend/interview/domain/Interview.java
@@ -32,5 +32,5 @@ public class Interview {
     private Integer numClubUser; //평가한 운영진의 수
 
     @Column(length = 100, nullable = true)
-    private String part; // 직렬화, 역직렬화 필요
+    private String recruit_group; // 직렬화, 역직렬화 필요
 }

--- a/src/main/java/com/cluting/clutingbackend/interview/domain/InterviewEvaluator.java
+++ b/src/main/java/com/cluting/clutingbackend/interview/domain/InterviewEvaluator.java
@@ -3,7 +3,7 @@ package com.cluting.clutingbackend.interview.domain;
 import com.cluting.clutingbackend.clubuser.domain.ClubUser;
 import com.cluting.clutingbackend.global.enums.EvaluateStatus;
 import com.cluting.clutingbackend.global.enums.Stage;
-import com.cluting.clutingbackend.plan.domain.Part;
+import com.cluting.clutingbackend.plan.domain.Group;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -27,8 +27,8 @@ public class InterviewEvaluator {
     private Interview interview;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "part_id", nullable = true)
-    private Part part;
+    @JoinColumn(name = "group_id", nullable = true)
+    private Group group;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = true)

--- a/src/main/java/com/cluting/clutingbackend/plan/domain/DocumentCriteria.java
+++ b/src/main/java/com/cluting/clutingbackend/plan/domain/DocumentCriteria.java
@@ -16,8 +16,8 @@ public class DocumentCriteria {
     private String content;
 
     @ManyToOne
-    @JoinColumn(name = "part_id", nullable = false)
-    private Part part;
+    @JoinColumn(name = "group_id", nullable = false)
+    private Group group;
 
     // Getter, Setter, Constructor
 }

--- a/src/main/java/com/cluting/clutingbackend/plan/domain/DocumentEvaluator.java
+++ b/src/main/java/com/cluting/clutingbackend/plan/domain/DocumentEvaluator.java
@@ -27,7 +27,7 @@ public class DocumentEvaluator {
     private Application application;
 
     @ManyToOne
-    @JoinColumn(name = "group_id", nullable = false)
+    @JoinColumn(name = "group_id", nullable = true)
     private Group group;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/cluting/clutingbackend/plan/domain/DocumentEvaluator.java
+++ b/src/main/java/com/cluting/clutingbackend/plan/domain/DocumentEvaluator.java
@@ -27,8 +27,8 @@ public class DocumentEvaluator {
     private Application application;
 
     @ManyToOne
-    @JoinColumn(name = "part_id", nullable = false)
-    private Part part;
+    @JoinColumn(name = "group_id", nullable = false)
+    private Group group;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = true)

--- a/src/main/java/com/cluting/clutingbackend/plan/domain/DocumentQuestion.java
+++ b/src/main/java/com/cluting/clutingbackend/plan/domain/DocumentQuestion.java
@@ -17,8 +17,8 @@ public class DocumentQuestion {
     private DocumentAnswer documentAnswer;
 
     @ManyToOne
-    @JoinColumn(name = "part_id", nullable = false)
-    private Part part;
+    @JoinColumn(name = "group_id", nullable = false)
+    private Group group;
 
     @Enumerated(EnumType.STRING)
     private QuestionType questionType;

--- a/src/main/java/com/cluting/clutingbackend/plan/domain/Group.java
+++ b/src/main/java/com/cluting/clutingbackend/plan/domain/Group.java
@@ -24,19 +24,19 @@ public class Group {
     @JoinColumn(name = "recruit_id", nullable = false)
     private Recruit recruit;
 
-    @Column
+    @Column(nullable = true)
     private String name;
 
-    @Column
-    private int numDoc;
+    @Column(nullable = true)
+    private Integer numDoc;
 
-    @Column
-    private int numFinal;
+    @Column(nullable = true)
+    private Integer numFinal;
 
-    @Column
-    private int numRecruit;
+    @Column(nullable = true)
+    private Integer numRecruit;
 
-    @Column
+    @Column(nullable = true)
     private String warning;
 
 }

--- a/src/main/java/com/cluting/clutingbackend/plan/domain/Group.java
+++ b/src/main/java/com/cluting/clutingbackend/plan/domain/Group.java
@@ -13,7 +13,8 @@ import lombok.Setter;
 @AllArgsConstructor
 @Getter
 @Setter
-public class Part {
+@Table(name = "recruit_group")
+public class Group {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/cluting/clutingbackend/plan/domain/TalentProfile.java
+++ b/src/main/java/com/cluting/clutingbackend/plan/domain/TalentProfile.java
@@ -11,8 +11,8 @@ public class TalentProfile {
     private Long id;
 
     @ManyToOne
-    @JoinColumn(name = "part_id", nullable = false)
-    private Part part;
+    @JoinColumn(name = "group_id", nullable = false)
+    private Group group;
 
     @Column
     private String profile; // 인재상 내용

--- a/src/main/java/com/cluting/clutingbackend/plan/repository/DocumentEvaluatorRepository.java
+++ b/src/main/java/com/cluting/clutingbackend/plan/repository/DocumentEvaluatorRepository.java
@@ -1,0 +1,24 @@
+package com.cluting.clutingbackend.plan.repository;
+
+import com.cluting.clutingbackend.plan.domain.DocumentEvaluator;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface DocumentEvaluatorRepository extends JpaRepository<DocumentEvaluator, Long> {
+    // [서류 평가하기] 평가 전 리스트 불러오기
+    @Query("SELECT de FROM DocumentEvaluator de WHERE de.application.id IN :applicationIds AND de.stage = 'BEFORE'")
+    List<DocumentEvaluator> findByApplicationIdsAndStageBefore(@Param("applicationIds") List<Long> applicationIds);
+
+    // [서류 평가하기] 지원서 ID로 DocumentEvaluator 찾기
+    DocumentEvaluator findByApplicationId(Long applicationId);
+
+    // [서류 평가하기] 평가할 전체 운영진 수
+    @Query("SELECT COUNT(DISTINCT de.clubUser.id) FROM DocumentEvaluator de " +
+            "JOIN de.application a WHERE a.recruit.id = :recruitId " +
+            "AND a.id = :applicationId")
+    int countUniqueClubUserIdsByRecruitIdAndApplicationId(Long recruitId, Long applicationId);
+
+}

--- a/src/main/java/com/cluting/clutingbackend/plan/repository/GroupRepository.java
+++ b/src/main/java/com/cluting/clutingbackend/plan/repository/GroupRepository.java
@@ -6,7 +6,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface GroupRepository extends JpaRepository<Group, Long> {
-    // [계획하기] 수정할 때 이미 있는 컬럼을 삭제 후 새로 추가하기 위함.
+    // [계획하기] 불러오기
     List<Group> findByRecruitId(Long recruitId);
+    // [계획하기] 수정할 때 이미 있는 컬럼을 삭제 후 새로 추가하기 위함.
     void deleteByRecruitId(Long recruitId);
 }

--- a/src/main/java/com/cluting/clutingbackend/plan/repository/GroupRepository.java
+++ b/src/main/java/com/cluting/clutingbackend/plan/repository/GroupRepository.java
@@ -1,0 +1,12 @@
+package com.cluting.clutingbackend.plan.repository;
+
+import com.cluting.clutingbackend.plan.domain.Group;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface GroupRepository extends JpaRepository<Group, Long> {
+    // [계획하기] 수정할 때 이미 있는 컬럼을 삭제 후 새로 추가하기 위함.
+    List<Group> findByRecruitId(Long recruitId);
+    void deleteByRecruitId(Long recruitId);
+}

--- a/src/main/java/com/cluting/clutingbackend/plan/repository/PartRepository.java
+++ b/src/main/java/com/cluting/clutingbackend/plan/repository/PartRepository.java
@@ -1,8 +1,0 @@
-package com.cluting.clutingbackend.plan.repository;
-
-import com.cluting.clutingbackend.plan.domain.Part;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface PartRepository extends JpaRepository<Part,Long> {
-
-}

--- a/src/main/java/com/cluting/clutingbackend/plan/service/PlanService.java
+++ b/src/main/java/com/cluting/clutingbackend/plan/service/PlanService.java
@@ -1,7 +1,7 @@
 package com.cluting.clutingbackend.plan.service;
 
 import com.cluting.clutingbackend.plan.dto.request.Plan1RequestDto;
-import com.cluting.clutingbackend.plan.repository.PartRepository;
+import com.cluting.clutingbackend.plan.repository.GroupRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -11,7 +11,7 @@ import java.util.List;
 public class PlanService {
     //공갈빵, 피스타치오크럼핀, 샐러드+소세지, 그릭요거트, 땅콩버터
     @Autowired
-    private PartRepository partRepository;
+    private GroupRepository groupRepository;
 
     public void setUpPartNums(List<Plan1RequestDto> plan1RequestDtos){
 

--- a/src/main/java/com/cluting/clutingbackend/prep/controller/PrepController.java
+++ b/src/main/java/com/cluting/clutingbackend/prep/controller/PrepController.java
@@ -1,0 +1,24 @@
+package com.cluting.clutingbackend.prep.controller;
+
+import com.cluting.clutingbackend.prep.dto.PrepRequestDto;
+import com.cluting.clutingbackend.prep.service.PrepService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/prep")
+@RequiredArgsConstructor
+public class PrepController {
+    private final PrepService prepService;
+
+    // [계획하기] 등록하기
+    @PostMapping
+    public ResponseEntity<Void> savePreparationDetails(
+            @RequestParam Long recruitId,
+            @RequestBody PrepRequestDto prepRequestDto
+    ) {
+        prepService.savePreparation(recruitId, prepRequestDto);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/cluting/clutingbackend/prep/controller/PrepController.java
+++ b/src/main/java/com/cluting/clutingbackend/prep/controller/PrepController.java
@@ -1,11 +1,16 @@
 package com.cluting.clutingbackend.prep.controller;
 
+import com.cluting.clutingbackend.prep.dto.PrepDetailsResponseDto;
 import com.cluting.clutingbackend.prep.dto.PrepRequestDto;
 import com.cluting.clutingbackend.prep.service.PrepService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "[1. 계획하기]", description = "계획하기 관련 API")
 @RestController
 @RequestMapping("/api/v1/prep")
 @RequiredArgsConstructor
@@ -13,6 +18,15 @@ public class PrepController {
     private final PrepService prepService;
 
     // [계획하기] 등록하기
+    @Operation(
+            summary = "[계획하기] 등록하기",
+            description = "모집 공고 ID와 리크루팅 일정, 모집 단계별 운영진, 지원자 그룹을 통해 계획하기 페이지를 등록합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "계획하기 페이지 조회 성공"),
+                    @ApiResponse(responseCode = "400", description = "모집 공고를 찾을 수 없음"),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+            }
+    )
     @PostMapping
     public ResponseEntity<Void> savePreparationDetails(
             @RequestParam Long recruitId,
@@ -20,5 +34,20 @@ public class PrepController {
     ) {
         prepService.savePreparation(recruitId, prepRequestDto);
         return ResponseEntity.ok().build();
+    }
+
+    // [계획하기] 불러오기
+    @Operation(
+            summary = "[계획하기] 불러오기",
+            description = "모집 공고 ID를 기반으로 리크루팅 일정, 모집 단계별 운영진, 지원자 그룹을 불러옵니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "계획하기 페이지 조회 성공"),
+                    @ApiResponse(responseCode = "400", description = "모집 공고를 찾을 수 없음"),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+            }
+    )
+    @GetMapping
+    public PrepDetailsResponseDto getPrepDetails(@RequestParam Long recruitId) {
+        return prepService.getPrepDetails(recruitId);
     }
 }

--- a/src/main/java/com/cluting/clutingbackend/prep/domain/PrepStage.java
+++ b/src/main/java/com/cluting/clutingbackend/prep/domain/PrepStage.java
@@ -22,7 +22,7 @@ public class PrepStage {
     @JoinColumn(name = "recruit_id", nullable = false)
     private Recruit recruit;
 
-    @OneToMany(mappedBy = "prepStage", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "prepStage", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<PrepStageClubUser> prepStageClubUser = new ArrayList<>();
 
     @Column(nullable = false)

--- a/src/main/java/com/cluting/clutingbackend/prep/dto/PrepDetailsResponseDto.java
+++ b/src/main/java/com/cluting/clutingbackend/prep/dto/PrepDetailsResponseDto.java
@@ -1,0 +1,16 @@
+package com.cluting.clutingbackend.prep.dto;
+
+import com.cluting.clutingbackend.recruit.dto.RecruitScheduleDto;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class PrepDetailsResponseDto {
+    private RecruitScheduleDto schedule;
+    private List<PrepStageResponseDto> prepStages;
+    private List<String> groups;
+    private List<String> admins;
+}

--- a/src/main/java/com/cluting/clutingbackend/prep/dto/PrepRequestDto.java
+++ b/src/main/java/com/cluting/clutingbackend/prep/dto/PrepRequestDto.java
@@ -1,0 +1,18 @@
+package com.cluting.clutingbackend.prep.dto;
+
+import com.cluting.clutingbackend.recruit.dto.RecruitScheduleDto;
+import lombok.*;
+
+import java.util.List;
+
+// [계획하기] 등록하기 DTO
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PrepRequestDto {
+    private List<RecruitScheduleDto> recruitSchedules; // 리크루팅 일정
+    private List<PrepStageDto> prepStages; // 모집 단계별 운영진
+    private List<String> applicantGroups; // 지원자 그룹
+}

--- a/src/main/java/com/cluting/clutingbackend/prep/dto/PrepStageDto.java
+++ b/src/main/java/com/cluting/clutingbackend/prep/dto/PrepStageDto.java
@@ -1,0 +1,17 @@
+package com.cluting.clutingbackend.prep.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+// [계획하기] 모집 단계별 운영진 목록
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PrepStageDto {
+    private String stageName;
+    private Integer stageOrder;
+    private List<Long> clubUserIds; // 운영진 ID 목록
+}

--- a/src/main/java/com/cluting/clutingbackend/prep/dto/PrepStageResponseDto.java
+++ b/src/main/java/com/cluting/clutingbackend/prep/dto/PrepStageResponseDto.java
@@ -1,0 +1,13 @@
+package com.cluting.clutingbackend.prep.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class PrepStageResponseDto {
+    private String stageName;
+    private List<String> adminNames;
+}

--- a/src/main/java/com/cluting/clutingbackend/prep/repository/PrepStageClubUserRepository.java
+++ b/src/main/java/com/cluting/clutingbackend/prep/repository/PrepStageClubUserRepository.java
@@ -1,0 +1,7 @@
+package com.cluting.clutingbackend.prep.repository;
+
+import com.cluting.clutingbackend.prep.domain.PrepStageClubUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PrepStageClubUserRepository extends JpaRepository<PrepStageClubUser, Long> {
+}

--- a/src/main/java/com/cluting/clutingbackend/prep/repository/PrepStageClubUserRepository.java
+++ b/src/main/java/com/cluting/clutingbackend/prep/repository/PrepStageClubUserRepository.java
@@ -3,5 +3,9 @@ package com.cluting.clutingbackend.prep.repository;
 import com.cluting.clutingbackend.prep.domain.PrepStageClubUser;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface PrepStageClubUserRepository extends JpaRepository<PrepStageClubUser, Long> {
+    // [계획하기] 불러오기
+    List<PrepStageClubUser> findByPrepStageId(Long prepStageId);
 }

--- a/src/main/java/com/cluting/clutingbackend/prep/repository/PrepStageRepository.java
+++ b/src/main/java/com/cluting/clutingbackend/prep/repository/PrepStageRepository.java
@@ -1,0 +1,12 @@
+package com.cluting.clutingbackend.prep.repository;
+
+import com.cluting.clutingbackend.prep.domain.PrepStage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PrepStageRepository extends JpaRepository<PrepStage, Long> {
+    // [계획하기] 수정할 때 이미 있는 컬럼을 삭제 후 새로 추가하기 위함.
+    List<PrepStage> findByRecruitId(Long recruitId);
+    void deleteByRecruitId(Long recruitId);
+}

--- a/src/main/java/com/cluting/clutingbackend/prep/repository/PrepStageRepository.java
+++ b/src/main/java/com/cluting/clutingbackend/prep/repository/PrepStageRepository.java
@@ -6,7 +6,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface PrepStageRepository extends JpaRepository<PrepStage, Long> {
-    // [계획하기] 수정할 때 이미 있는 컬럼을 삭제 후 새로 추가하기 위함.
+    // [계획하기] 불러오기
     List<PrepStage> findByRecruitId(Long recruitId);
+    // [계획하기] 수정할 때 이미 있는 컬럼을 삭제 후 새로 추가하기 위함.
     void deleteByRecruitId(Long recruitId);
 }

--- a/src/main/java/com/cluting/clutingbackend/prep/service/PrepService.java
+++ b/src/main/java/com/cluting/clutingbackend/prep/service/PrepService.java
@@ -1,0 +1,109 @@
+package com.cluting.clutingbackend.prep.service;
+
+import com.cluting.clutingbackend.clubuser.domain.ClubUser;
+import com.cluting.clutingbackend.clubuser.repository.ClubUserRepository;
+import com.cluting.clutingbackend.global.enums.CurrentStage;
+import com.cluting.clutingbackend.plan.domain.Group;
+import com.cluting.clutingbackend.plan.repository.GroupRepository;
+import com.cluting.clutingbackend.prep.domain.PrepStage;
+import com.cluting.clutingbackend.prep.domain.PrepStageClubUser;
+import com.cluting.clutingbackend.prep.dto.PrepRequestDto;
+import com.cluting.clutingbackend.prep.dto.PrepStageDto;
+import com.cluting.clutingbackend.prep.repository.PrepStageClubUserRepository;
+import com.cluting.clutingbackend.prep.repository.PrepStageRepository;
+import com.cluting.clutingbackend.recruit.domain.Recruit;
+import com.cluting.clutingbackend.recruit.domain.RecruitSchedule;
+import com.cluting.clutingbackend.recruit.dto.RecruitScheduleDto;
+import com.cluting.clutingbackend.recruit.repository.RecruitRepository;
+import com.cluting.clutingbackend.recruit.repository.RecruitScheduleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PrepService {
+    private final RecruitScheduleRepository recruitScheduleRepository;
+    private final RecruitRepository recruitRepository;
+    private final PrepStageRepository prepStageRepository;
+    private final PrepStageClubUserRepository prepStageClubUserRepository;
+    private final ClubUserRepository clubUserRepository;
+    private final GroupRepository groupRepository;
+
+    // [계획하기] 설정 완료하기
+    @Transactional
+    public void savePreparation(Long recruitId, PrepRequestDto prepRequestDto) {
+        Recruit recruit = recruitRepository.findById(recruitId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 모집 공고를 찾을 수 없습니다. id: " + recruitId));
+
+        // 1. 리크루팅 일정 저장
+        RecruitSchedule recruitSchedule = recruitScheduleRepository.findByRecruitId(recruitId)
+                .orElse(new RecruitSchedule());
+
+        recruitSchedule.setRecruit(recruit);
+
+        recruitSchedule.setStage1Start(prepRequestDto.getRecruitSchedules().get(0).getStage1Start());
+        recruitSchedule.setStage1End(prepRequestDto.getRecruitSchedules().get(0).getStage1End());
+        recruitSchedule.setStage2Start(prepRequestDto.getRecruitSchedules().get(0).getStage2Start());
+        recruitSchedule.setStage2End(prepRequestDto.getRecruitSchedules().get(0).getStage2End());
+        recruitSchedule.setStage3Start(prepRequestDto.getRecruitSchedules().get(0).getStage3Start());
+        recruitSchedule.setStage3End(prepRequestDto.getRecruitSchedules().get(0).getStage3End());
+        recruitSchedule.setStage4Start(prepRequestDto.getRecruitSchedules().get(0).getStage4Start());
+        recruitSchedule.setStage4End(prepRequestDto.getRecruitSchedules().get(0).getStage4End());
+        recruitSchedule.setStage5Start(prepRequestDto.getRecruitSchedules().get(0).getStage5Start());
+        recruitSchedule.setStage5End(prepRequestDto.getRecruitSchedules().get(0).getStage5End());
+        recruitSchedule.setStage6Start(prepRequestDto.getRecruitSchedules().get(0).getStage6Start());
+        recruitSchedule.setStage6End(prepRequestDto.getRecruitSchedules().get(0).getStage6End());
+
+        recruitScheduleRepository.save(recruitSchedule);
+
+        // 2. 모집 단계 및 운영진 저장
+        if (!prepStageRepository.findByRecruitId(recruitId).isEmpty()) {
+            prepStageRepository.deleteByRecruitId(recruitId);
+        }
+
+        for (PrepStageDto stageDto : prepRequestDto.getPrepStages()) {
+            PrepStage prepStage = PrepStage.builder()
+                    .recruit(recruit)
+                    .stageName(stageDto.getStageName())
+                    .stageOrder(stageDto.getStageOrder())
+                    .build();
+            prepStageRepository.save(prepStage);
+
+            for (Long clubUserId : stageDto.getClubUserIds()) {
+                ClubUser clubUser = clubUserRepository.findById(clubUserId)
+                        .orElseThrow(() -> new IllegalArgumentException("해당 ClubUser 찾지 못함. id: " + clubUserId));
+
+                PrepStageClubUser prepStageClubUser = PrepStageClubUser.builder()
+                        .prepStage(prepStage)
+                        .clubUser(clubUser)
+                        .build();
+                prepStageClubUserRepository.save(prepStageClubUser);
+            }
+        }
+
+        // 3. 지원자 그룹 저장
+        if (!groupRepository.findByRecruitId(recruitId).isEmpty()) {
+            groupRepository.deleteByRecruitId(recruitId);
+        }
+
+        List<String> applicantGroups = prepRequestDto.getApplicantGroups();
+        if (applicantGroups.isEmpty()) {
+            applicantGroups = List.of("공통");
+        }
+
+        for (String groupName : applicantGroups) {
+            Group group = new Group();
+            group.setRecruit(recruit);
+            group.setName(groupName);
+            groupRepository.save(group);
+        }
+
+        // 4. 현재 진행 중인 리크루팅 단계 PREP으로 변경
+        recruit.setCurrentStage(CurrentStage.PREP);
+        recruitRepository.save(recruit);
+    }
+}

--- a/src/main/java/com/cluting/clutingbackend/prep/service/PrepService.java
+++ b/src/main/java/com/cluting/clutingbackend/prep/service/PrepService.java
@@ -105,8 +105,8 @@ public class PrepService {
             groupRepository.save(group);
         }
 
-        // 4. 현재 진행 중인 리크루팅 단계 PREP으로 변경
-        recruit.setCurrentStage(CurrentStage.PREP);
+        // 4. 현재 진행 중인 리크루팅 단계 PLAN으로 변경
+        recruit.setCurrentStage(CurrentStage.PLAN);
         recruitRepository.save(recruit);
     }
 

--- a/src/main/java/com/cluting/clutingbackend/recruit/controller/RecruitController.java
+++ b/src/main/java/com/cluting/clutingbackend/recruit/controller/RecruitController.java
@@ -12,7 +12,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "리크루팅 홈", description = "리크루팅 홈 관련 API")
+@Tag(name = "[리크루팅 홈]", description = "리크루팅 홈 관련 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/recruiting")

--- a/src/main/java/com/cluting/clutingbackend/recruit/controller/RecruitController.java
+++ b/src/main/java/com/cluting/clutingbackend/recruit/controller/RecruitController.java
@@ -1,11 +1,48 @@
 package com.cluting.clutingbackend.recruit.controller;
 
+import com.cluting.clutingbackend.global.security.CustomUserDetails;
+import com.cluting.clutingbackend.global.security.CustomUserDetailsService;
+import com.cluting.clutingbackend.global.security.JwtProvider;
+import com.cluting.clutingbackend.recruit.dto.RecruitHomeDto;
 import com.cluting.clutingbackend.recruit.service.RecruitService;
+import com.cluting.clutingbackend.user.domain.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "리크루팅 홈", description = "리크루팅 홈 관련 API")
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/v1/recruiting")
 public class RecruitController {
     private final RecruitService recruitService;
+    private final JwtProvider jwtProvider;
+    private final CustomUserDetailsService customUserDetailsService;
+
+    // [리크루팅 홈] 불러오기
+    @Operation(
+            summary = "[리크루팅 홈] 불러오기",
+            description = "동아리 ID와 모집 공고 ID를 기반으로 리크루팅 홈 데이터를 반환합니다. 반환 데이터에는 동아리 정보, 모집 공고 정보, 리크루팅 일정, 운영진 목록, TODO 목록이 포함됩니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "리크루팅 홈 데이터 조회 성공"),
+                    @ApiResponse(responseCode = "400", description = "클럽 또는 모집 공고를 찾을 수 없음"),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+            }
+    )
+    @GetMapping
+    public RecruitHomeDto getRecruitHome(
+            @RequestParam Long recruitId,
+            @RequestParam Long clubId,
+            @RequestHeader("Authorization") String token) {
+        // 토큰에서 이메일 추출
+        String email = jwtProvider.getUserEmail(token);
+
+        // 이메일을 통해 User 객체 조회
+        User user = ((CustomUserDetails) customUserDetailsService.loadUserByUserId(email)).getUser();
+        Long clubUserId = user.getId();
+
+        return recruitService.getRecruitHome(recruitId, clubId, clubUserId);
+    }
 }

--- a/src/main/java/com/cluting/clutingbackend/recruit/domain/Recruit.java
+++ b/src/main/java/com/cluting/clutingbackend/recruit/domain/Recruit.java
@@ -46,6 +46,9 @@ public class Recruit {
     private CurrentStage currentStage;  // 현재 진행중인 리크루팅 단계
 
     @Column(nullable = true)
+    private Integer generation; //기수
+
+    @Column(nullable = true)
     private Boolean isInterview; // true : 면접까지 진행 | false : 서류까지 진행
 
     @Column

--- a/src/main/java/com/cluting/clutingbackend/recruit/domain/Recruit.java
+++ b/src/main/java/com/cluting/clutingbackend/recruit/domain/Recruit.java
@@ -33,7 +33,8 @@ public class Recruit {
     private String image; // 공고 이미지 경로
 
     @Column(nullable = true)
-    private Boolean isDone; // 마감여부
+    @Builder.Default
+    private Boolean isDone = false; // 마감여부
 
     @Column(length = 255, nullable = true)
     private String caution; // 공고 질문 관련 주의 사항
@@ -65,4 +66,7 @@ public class Recruit {
 
     @Column
     private Integer interviewDuration; // 면접 소요 시간
+
+    @Column(nullable = true)
+    private String interviewLocation; // 면접 장소
 }

--- a/src/main/java/com/cluting/clutingbackend/recruit/domain/Recruit.java
+++ b/src/main/java/com/cluting/clutingbackend/recruit/domain/Recruit.java
@@ -9,6 +9,7 @@ import java.time.LocalDateTime;
 
 @Entity
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)

--- a/src/main/java/com/cluting/clutingbackend/recruit/domain/RecruitSchedule.java
+++ b/src/main/java/com/cluting/clutingbackend/recruit/domain/RecruitSchedule.java
@@ -7,8 +7,9 @@ import java.time.LocalDate;
 
 @Entity
 @Getter
+@Setter
 @Builder
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Table(name = "tb_recruitschedule")
 public class RecruitSchedule {

--- a/src/main/java/com/cluting/clutingbackend/recruit/domain/RecruitSchedule.java
+++ b/src/main/java/com/cluting/clutingbackend/recruit/domain/RecruitSchedule.java
@@ -20,54 +20,51 @@ public class RecruitSchedule {
     @JoinColumn(name = "recruit_id", nullable = false)
     private Recruit recruit;
 
-    @Column(name = "stage_1_end", nullable = false)
+    @Column(name = "stage_1_end", nullable = true)
     private LocalDate stage1End;
 
-    @Column(name = "stage_1_start", nullable = false)
+    @Column(name = "stage_1_start", nullable = true)
     private LocalDate stage1Start;
 
-    @Column(name = "stage_2_start", nullable = false)
+    @Column(name = "stage_2_start", nullable = true)
     private LocalDate stage2Start;
 
-    @Column(name = "stage_2_end", nullable = false)
+    @Column(name = "stage_2_end", nullable = true)
     private LocalDate stage2End;
 
-    @Column(name = "stage_3_start", nullable = false)
+    @Column(name = "stage_3_start", nullable = true)
     private LocalDate stage3Start;
 
-    @Column(name = "stage_3_end", nullable = false)
+    @Column(name = "stage_3_end", nullable = true)
     private LocalDate stage3End;
 
-    @Column(name = "stage_4_start", nullable = false)
+    @Column(name = "stage_4_start", nullable = true)
     private LocalDate stage4Start;
 
-    @Column(name = "stage_4_end", nullable = false)
+    @Column(name = "stage_4_end", nullable = true)
     private LocalDate stage4End;
 
-    @Column(name = "stage_5_start", nullable = false)
+    @Column(name = "stage_5_start", nullable = true)
     private LocalDate stage5Start;
 
-    @Column(name = "stage_5_end", nullable = false)
+    @Column(name = "stage_5_end", nullable = true)
     private LocalDate stage5End;
 
-    @Column(name = "stage_6_start", nullable = false)
+    @Column(name = "stage_6_start", nullable = true)
     private LocalDate stage6Start;
 
-    @Column(name = "stage_6_end", nullable = false)
+    @Column(name = "stage_6_end", nullable = true)
     private LocalDate stage6End;
 
-    @Column(name = "stage_7_start", nullable = false)
+    @Column(name = "stage_7_start", nullable = true)
     private LocalDate stage7Start;
 
-    @Column(name = "stage_7_end", nullable = false)
+    @Column(name = "stage_7_end", nullable = true)
     private LocalDate stage7End;
 
-    @Column(name = "stage_8_start", nullable = false)
+    @Column(name = "stage_8_start", nullable = true)
     private LocalDate stage8Start;
 
-    @Column(name = "stage_8_end", nullable = false)
+    @Column(name = "stage_8_end", nullable = true)
     private LocalDate stage8End;
-
-    @Column(name = "interview_location", nullable = true)
-    private String interviewLocation;
 }

--- a/src/main/java/com/cluting/clutingbackend/recruit/dto/ClubUserInfoDto.java
+++ b/src/main/java/com/cluting/clutingbackend/recruit/dto/ClubUserInfoDto.java
@@ -1,0 +1,12 @@
+package com.cluting.clutingbackend.recruit.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+// [리크루팅 홈] 운영진 리스트 GET
+public class ClubUserInfoDto {
+    private String name;
+    private String email;
+}

--- a/src/main/java/com/cluting/clutingbackend/recruit/dto/RecruitClubInfoDto.java
+++ b/src/main/java/com/cluting/clutingbackend/recruit/dto/RecruitClubInfoDto.java
@@ -1,0 +1,16 @@
+package com.cluting.clutingbackend.recruit.dto;
+
+import com.cluting.clutingbackend.global.enums.CurrentStage;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+// [리크루팅 홈] 동아리 정보 GET
+public class RecruitClubInfoDto {
+    private String clubName;  //동아리 이름
+    private String clubProfile;  //동아리 프로필
+    private Boolean isInterview;  //면접까지 진행하는지, 서류까지만 진행하는지 -> 이에 따라 메뉴가 달라짐
+    private Integer generation;  //기수
+    private CurrentStage currentStage;  //현재 진행중인 리크루팅 단계
+}

--- a/src/main/java/com/cluting/clutingbackend/recruit/dto/RecruitClubInfoDto.java
+++ b/src/main/java/com/cluting/clutingbackend/recruit/dto/RecruitClubInfoDto.java
@@ -1,11 +1,15 @@
 package com.cluting.clutingbackend.recruit.dto;
 
 import com.cluting.clutingbackend.global.enums.CurrentStage;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor
 // [리크루팅 홈] 동아리 정보 GET
 public class RecruitClubInfoDto {
     private String clubName;  //동아리 이름

--- a/src/main/java/com/cluting/clutingbackend/recruit/dto/RecruitHomeDto.java
+++ b/src/main/java/com/cluting/clutingbackend/recruit/dto/RecruitHomeDto.java
@@ -1,0 +1,16 @@
+package com.cluting.clutingbackend.recruit.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+// [리크루팅 홈] 불러오기
+public class RecruitHomeDto {
+    private RecruitClubInfoDto recruitInfo;
+    private RecruitScheduleDto recruitSchedule;
+    private List<ClubUserInfoDto> adminList;
+    private List<TodoDto> userTodos;
+}

--- a/src/main/java/com/cluting/clutingbackend/recruit/dto/RecruitScheduleDto.java
+++ b/src/main/java/com/cluting/clutingbackend/recruit/dto/RecruitScheduleDto.java
@@ -1,12 +1,15 @@
 package com.cluting.clutingbackend.recruit.dto;
 
-import lombok.Builder;
-import lombok.Data;
+import lombok.*;
 
 import java.time.LocalDate;
 
+@Getter
+@Setter
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 // [리크루팅 홈] 리크루팅 일정 GET
 public class RecruitScheduleDto {
     private LocalDate stage1Start; //리크루팅 준비 기간(서류까지만 리크루팅 하는 경우)

--- a/src/main/java/com/cluting/clutingbackend/recruit/dto/RecruitScheduleDto.java
+++ b/src/main/java/com/cluting/clutingbackend/recruit/dto/RecruitScheduleDto.java
@@ -1,0 +1,28 @@
+package com.cluting.clutingbackend.recruit.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDate;
+
+@Data
+@Builder
+// [리크루팅 홈] 리크루팅 일정 GET
+public class RecruitScheduleDto {
+    private LocalDate stage1Start; //리크루팅 준비 기간(서류까지만 리크루팅 하는 경우)
+    private LocalDate stage1End;
+    private LocalDate stage2Start;  //공고 업로드
+    private LocalDate stage2End;
+    private LocalDate stage3Start;  //모집기간(서류까지만 리크루팅 하는 경우)
+    private LocalDate stage3End;
+    private LocalDate stage4Start;  //서류평가기간(서류까지만 리크루팅 하는 경우)
+    private LocalDate stage4End;
+    private LocalDate stage5Start;  //1차 합격자 발표
+    private LocalDate stage5End;
+    private LocalDate stage6Start;  //면접 기간
+    private LocalDate stage6End;
+    private LocalDate stage7Start;  //면접 평가 기간
+    private LocalDate stage7End;
+    private LocalDate stage8Start;  //최종 합격자 발표(서류까지만 리크루팅 하는 경우)
+    private LocalDate stage8End;
+}

--- a/src/main/java/com/cluting/clutingbackend/recruit/dto/TodoDto.java
+++ b/src/main/java/com/cluting/clutingbackend/recruit/dto/TodoDto.java
@@ -1,0 +1,12 @@
+package com.cluting.clutingbackend.recruit.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+// [리크루팅 홈] 개인 투두 리스트 GET
+public class TodoDto {
+    private String content;
+    private Boolean status;
+}

--- a/src/main/java/com/cluting/clutingbackend/recruit/dto/TodoDto.java
+++ b/src/main/java/com/cluting/clutingbackend/recruit/dto/TodoDto.java
@@ -7,6 +7,7 @@ import lombok.Data;
 @Builder
 // [리크루팅 홈] 개인 투두 리스트 GET
 public class TodoDto {
+    private Long todoId;
     private String content;
     private Boolean status;
 }

--- a/src/main/java/com/cluting/clutingbackend/recruit/repository/RecruitRepository.java
+++ b/src/main/java/com/cluting/clutingbackend/recruit/repository/RecruitRepository.java
@@ -2,8 +2,12 @@ package com.cluting.clutingbackend.recruit.repository;
 
 import com.cluting.clutingbackend.recruit.domain.Recruit;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface RecruitRepository extends JpaRepository<Recruit, Long> {
+    // [리크루팅 홈] 모집공고 정보 가져오기
+    @Query("SELECT r FROM Recruit r WHERE r.id = :recruitId")
+    Recruit findRecruitById(Long recruitId);
 }

--- a/src/main/java/com/cluting/clutingbackend/recruit/repository/RecruitScheduleRepository.java
+++ b/src/main/java/com/cluting/clutingbackend/recruit/repository/RecruitScheduleRepository.java
@@ -5,9 +5,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface RecruitScheduleRepository extends JpaRepository<RecruitSchedule, Long> {
     // [리크루팅 홈] 리크루팅 일정 가져오기
     @Query("SELECT rs FROM RecruitSchedule rs WHERE rs.recruit.id = :recruitId")
     RecruitSchedule findScheduleByRecruitId(Long recruitId);
+    Optional<RecruitSchedule> findByRecruitId(Long recruitId);
 }

--- a/src/main/java/com/cluting/clutingbackend/recruit/repository/RecruitScheduleRepository.java
+++ b/src/main/java/com/cluting/clutingbackend/recruit/repository/RecruitScheduleRepository.java
@@ -2,8 +2,12 @@ package com.cluting.clutingbackend.recruit.repository;
 
 import com.cluting.clutingbackend.recruit.domain.RecruitSchedule;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface RecruitScheduleRepository extends JpaRepository<RecruitSchedule, Long> {
+    // [리크루팅 홈] 리크루팅 일정 가져오기
+    @Query("SELECT rs FROM RecruitSchedule rs WHERE rs.recruit.id = :recruitId")
+    RecruitSchedule findScheduleByRecruitId(Long recruitId);
 }

--- a/src/main/java/com/cluting/clutingbackend/recruit/repository/RecruitScheduleRepository.java
+++ b/src/main/java/com/cluting/clutingbackend/recruit/repository/RecruitScheduleRepository.java
@@ -12,5 +12,7 @@ public interface RecruitScheduleRepository extends JpaRepository<RecruitSchedule
     // [리크루팅 홈] 리크루팅 일정 가져오기
     @Query("SELECT rs FROM RecruitSchedule rs WHERE rs.recruit.id = :recruitId")
     RecruitSchedule findScheduleByRecruitId(Long recruitId);
+    // [계획하기] 불러오기
     Optional<RecruitSchedule> findByRecruitId(Long recruitId);
+
 }

--- a/src/main/java/com/cluting/clutingbackend/recruit/service/RecruitService.java
+++ b/src/main/java/com/cluting/clutingbackend/recruit/service/RecruitService.java
@@ -32,16 +32,19 @@ public class RecruitService {
         List<TodoDto> userTodos = getUserTodos(clubId, clubUserId);
 
         return RecruitHomeDto.builder()
-                .recruitInfo(recruitInfo)
-                .recruitSchedule(recruitSchedule)
-                .adminList(adminList)
-                .userTodos(userTodos)
+                .recruitInfo(recruitInfo != null ? recruitInfo : new RecruitClubInfoDto())
+                .recruitSchedule(recruitSchedule != null ? recruitSchedule : new RecruitScheduleDto())
+                .adminList(adminList != null ? adminList : List.of())
+                .userTodos(userTodos != null ? userTodos : List.of())
                 .build();
     }
 
     // [리크루팅 홈] 동아리 정보 가져오기
     public RecruitClubInfoDto getRecruitInfo(Long recruitId) {
         Recruit recruit = recruitRepository.findRecruitById(recruitId);
+        if (recruit == null || recruit.getClub() == null) {
+            return new RecruitClubInfoDto();
+        }
         Club club = recruit.getClub();
 
         return RecruitClubInfoDto.builder()
@@ -56,6 +59,10 @@ public class RecruitService {
     // [리크루팅 홈] 리크루팅 일정 가져오기
     public RecruitScheduleDto getRecruitSchedule(Long recruitId) {
         RecruitSchedule schedule = recruitScheduleRepository.findScheduleByRecruitId(recruitId);
+        if (schedule == null) {
+            return new RecruitScheduleDto();
+        }
+
         return RecruitScheduleDto.builder()
                 .stage1Start(schedule.getStage1Start()) //리크루팅 준비 기간
                 .stage1End(schedule.getStage1End())
@@ -79,6 +86,10 @@ public class RecruitService {
     // [리크루팅 홈] 운영진 리스트 가져오기
     public List<ClubUserInfoDto> getAdminList(Long clubId) {
         List<ClubUser> staffList = clubUserRepository.findStaffByClubIdAndGeneration(clubId);
+        if (staffList == null || staffList.isEmpty()) {
+            return List.of();
+        }
+
         return staffList.stream()
                 .map(cu -> ClubUserInfoDto.builder()
                         .name(cu.getUser().getName())
@@ -90,7 +101,14 @@ public class RecruitService {
     // [리크루팅 홈] 운영진 투두 리스트 가져오기
     public List<TodoDto> getUserTodos(Long clubId, Long clubUserId) {
         ClubUser clubUser = clubUserRepository.findByClubIdAndUserId(clubId, clubUserId);  //해당 운영진
+        if (clubUser == null) {
+            return List.of();
+        }
         List<Todo> todos = todoRepository.findTodosByUserId(clubUser.getUser().getId());  //해당 운영진의 투두 리스트
+        if (todos == null || todos.isEmpty()) {
+            return List.of();
+        }
+
         return todos.stream()
                 .map(todo -> TodoDto.builder()
                         .todoId(todo.getId())

--- a/src/main/java/com/cluting/clutingbackend/recruit/service/RecruitService.java
+++ b/src/main/java/com/cluting/clutingbackend/recruit/service/RecruitService.java
@@ -1,13 +1,101 @@
 package com.cluting.clutingbackend.recruit.service;
 
+import com.cluting.clutingbackend.club.domain.Club;
+import com.cluting.clutingbackend.clubuser.domain.ClubUser;
+import com.cluting.clutingbackend.clubuser.repository.ClubUserRepository;
+import com.cluting.clutingbackend.recruit.domain.Recruit;
+import com.cluting.clutingbackend.recruit.domain.RecruitSchedule;
+import com.cluting.clutingbackend.recruit.dto.*;
 import com.cluting.clutingbackend.recruit.repository.RecruitRepository;
 import com.cluting.clutingbackend.recruit.repository.RecruitScheduleRepository;
+import com.cluting.clutingbackend.todo.domain.Todo;
+import com.cluting.clutingbackend.todo.repository.TodoRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class RecruitService {
     private final RecruitRepository recruitRepository;
     private final RecruitScheduleRepository recruitScheduleRepository;
+    private final ClubUserRepository clubUserRepository;
+    private final TodoRepository todoRepository;
+
+    // [리크루팅 홈] 불러오기
+    public RecruitHomeDto getRecruitHome(Long recruitId, Long clubId, Long clubUserId) {
+        RecruitClubInfoDto recruitInfo = getRecruitInfo(recruitId);
+        RecruitScheduleDto recruitSchedule = getRecruitSchedule(recruitId);
+        List<ClubUserInfoDto> adminList = getAdminList(clubId);
+        List<TodoDto> userTodos = getUserTodos(clubId, clubUserId);
+
+        return RecruitHomeDto.builder()
+                .recruitInfo(recruitInfo)
+                .recruitSchedule(recruitSchedule)
+                .adminList(adminList)
+                .userTodos(userTodos)
+                .build();
+    }
+
+    // [리크루팅 홈] 동아리 정보 가져오기
+    public RecruitClubInfoDto getRecruitInfo(Long recruitId) {
+        Recruit recruit = recruitRepository.findRecruitById(recruitId);
+        Club club = recruit.getClub();
+
+        return RecruitClubInfoDto.builder()
+                .clubName(club.getName())  //동아리 이름
+                .clubProfile(club.getProfile())  //동아리 프로필
+                .isInterview(recruit.getIsInterview())  //면접까지 진행하는지, 서류까지만 진행하는지 -> 이에 따라 메뉴가 달라짐
+                .generation(recruit.getGeneration())  //기수
+                .currentStage(recruit.getCurrentStage())  //현재 진행중인 리크루팅 단계
+                .build();
+    }
+
+    // [리크루팅 홈] 리크루팅 일정 가져오기
+    public RecruitScheduleDto getRecruitSchedule(Long recruitId) {
+        RecruitSchedule schedule = recruitScheduleRepository.findScheduleByRecruitId(recruitId);
+        return RecruitScheduleDto.builder()
+                .stage1Start(schedule.getStage1Start()) //리크루팅 준비 기간
+                .stage1End(schedule.getStage1End())
+                .stage2Start(schedule.getStage2Start()) //공고 업로드
+                .stage2End(schedule.getStage2End())
+                .stage3Start(schedule.getStage3Start()) //모집기간
+                .stage3End(schedule.getStage3End())
+                .stage4Start(schedule.getStage4Start()) //서류평가기간
+                .stage4End(schedule.getStage4End())
+                .stage5Start(schedule.getStage5Start()) //1차 합격자 발표
+                .stage5End(schedule.getStage5End())
+                .stage6Start(schedule.getStage6Start()) //면접 기간
+                .stage6End(schedule.getStage6End())
+                .stage7Start(schedule.getStage7Start()) //면접 평가 기간
+                .stage7End(schedule.getStage7End())
+                .stage8Start(schedule.getStage8Start()) //최종 합격자 발표
+                .stage8End(schedule.getStage8End())
+                .build();
+    }
+
+    // [리크루팅 홈] 운영진 리스트 가져오기
+    public List<ClubUserInfoDto> getAdminList(Long clubId) {
+        List<ClubUser> staffList = clubUserRepository.findStaffByClubIdAndGeneration(clubId);
+        return staffList.stream()
+                .map(cu -> ClubUserInfoDto.builder()
+                        .name(cu.getUser().getName())
+                        .email(cu.getUser().getEmail())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    // [리크루팅 홈] 운영진 투두 리스트 가져오기
+    public List<TodoDto> getUserTodos(Long clubId, Long clubUserId) {
+        ClubUser clubUser = clubUserRepository.findByClubIdAndUserId(clubId, clubUserId);  //해당 운영진
+        List<Todo> todos = todoRepository.findTodosByUserId(clubUser.getUser().getId());  //해당 운영진의 투두 리스트
+        return todos.stream()
+                .map(todo -> TodoDto.builder()
+                        .content(todo.getContent())
+                        .status(todo.getStatus())
+                        .build())
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/cluting/clutingbackend/recruit/service/RecruitService.java
+++ b/src/main/java/com/cluting/clutingbackend/recruit/service/RecruitService.java
@@ -93,6 +93,7 @@ public class RecruitService {
         List<Todo> todos = todoRepository.findTodosByUserId(clubUser.getUser().getId());  //해당 운영진의 투두 리스트
         return todos.stream()
                 .map(todo -> TodoDto.builder()
+                        .todoId(todo.getId())
                         .content(todo.getContent())
                         .status(todo.getStatus())
                         .build())

--- a/src/main/java/com/cluting/clutingbackend/todo/controller/TodoController.java
+++ b/src/main/java/com/cluting/clutingbackend/todo/controller/TodoController.java
@@ -8,7 +8,6 @@ import com.cluting.clutingbackend.todo.dto.TodoResponse;
 import com.cluting.clutingbackend.todo.service.TodoService;
 import com.cluting.clutingbackend.user.domain.User;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/cluting/clutingbackend/todo/controller/TodoController.java
+++ b/src/main/java/com/cluting/clutingbackend/todo/controller/TodoController.java
@@ -1,11 +1,141 @@
 package com.cluting.clutingbackend.todo.controller;
 
+import com.cluting.clutingbackend.global.security.CustomUserDetails;
+import com.cluting.clutingbackend.global.security.CustomUserDetailsService;
+import com.cluting.clutingbackend.global.security.JwtProvider;
+import com.cluting.clutingbackend.todo.dto.TodoRequest;
+import com.cluting.clutingbackend.todo.dto.TodoResponse;
 import com.cluting.clutingbackend.todo.service.TodoService;
+import com.cluting.clutingbackend.user.domain.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+import java.util.Map;
+
+@Tag(name = "[리크루팅 홈] 투두", description = "리크루팅 홈 - 투두 관련 API")
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/v1/todo")
 public class TodoController {
     private final TodoService todoService;
+    private final JwtProvider jwtProvider;
+    private final CustomUserDetailsService customUserDetailsService;
+
+    // [리크루팅 홈] 투두 작성하기
+    @Operation(
+            summary = "[리크루팅 홈] 투두 작성하기",
+            description = "리크루팅 홈에서 투두를 작성합니다. 투두 내용과 상태(true면 완료, false면 미완료)를 전달 받습니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "투두 작성 성공"),
+                    @ApiResponse(responseCode = "401", description = "유효하지 않은 인증 토큰"),
+                    @ApiResponse(responseCode = "404", description = "해당 투두 항목을 찾을 수 없음"),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+            }
+    )
+    @PostMapping
+    public ResponseEntity<TodoResponse> createTodo(
+            @RequestBody TodoRequest request,
+            @RequestHeader("Authorization") String token
+    ) {
+        Long clubUserId = getClubUserIdFromToken(token);
+        return ResponseEntity.ok(todoService.createTodo(clubUserId, request));
+    }
+
+    // 개인(운영진) 투두 삭제하기
+    @Operation(
+            summary = "[리크루팅 홈] 투두 삭제하기",
+            description = "투두 ID와 유저 ID를 기반으로 리크루팅 홈에서 해당 투두를 삭제합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "투두 삭제 성공"),
+                    @ApiResponse(responseCode = "401", description = "유효하지 않은 인증 토큰"),
+                    @ApiResponse(responseCode = "404", description = "해당 투두 항목을 찾을 수 없음"),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+            }
+    )
+    @DeleteMapping("/{todoId}")
+    public ResponseEntity<Void> deleteTodo(
+            @PathVariable Long todoId,
+            @RequestHeader("Authorization") String token
+    ) {
+        Long clubUserId = getClubUserIdFromToken(token);
+        todoService.deleteTodo(clubUserId, todoId);
+        return ResponseEntity.noContent().build();
+    }
+
+    // [리크루팅 홈] 투두 완료 상태 바꾸기
+    @Operation(
+            summary = "[리크루팅 홈] 투두 완료 상태 바꾸기",
+            description = "투두 ID와 유저 ID를 기반으로 해당 투두의 완료 상태(true:완료, false:미완료)를 변경합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "투두 완료 상태 변경 성공"),
+                    @ApiResponse(responseCode = "401", description = "유효하지 않은 인증 토큰"),
+                    @ApiResponse(responseCode = "404", description = "해당 투두 항목을 찾을 수 없음"),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+            }
+    )
+    @PatchMapping("/status/{todoId}")
+    public ResponseEntity<Void> toggleTodoStatus(
+            @PathVariable Long todoId,
+            @RequestHeader("Authorization") String token
+    ) {
+        Long clubUserId = getClubUserIdFromToken(token);
+        todoService.toggleTodoStatus(clubUserId, todoId);
+        return ResponseEntity.noContent().build();
+    }
+
+    // [리크루팅 홈] 투두 내용 변경하기
+    @Operation(
+            summary = "[리크루팅 홈] 투두 내용 변경하기",
+            description = "투두 ID와 유저 ID, 투두 내용을 기반으로 해당 투두의 내용을 변경합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "투두 내용 변경하기 성공"),
+                    @ApiResponse(responseCode = "401", description = "유효하지 않은 인증 토큰"),
+                    @ApiResponse(responseCode = "404", description = "해당 투두 항목을 찾을 수 없음"),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+            }
+    )
+    @PatchMapping("/{todoId}")
+    public ResponseEntity<Void> updateTodoContent(
+            @RequestHeader("Authorization") String token,
+            @PathVariable Long todoId,
+            @RequestBody TodoRequest request
+    ) {
+        Long clubUserId = getClubUserIdFromToken(token);
+        todoService.updateTodoContent(clubUserId, todoId, request.getContent());
+        return ResponseEntity.ok().build();
+    }
+
+    // [리크루팅 홈] 투두 리스트 완료/미완료 상태 분리해서 가져오기
+    @Operation(
+            summary = "[리크루팅 홈] 투두 완료 상태 바꾸기",
+            description = "투두 ID와 유저 ID를 기반으로 해당 투두의 완료 상태(true:완료, false:미완료)를 변경합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "투두 리스트 불러오기 성공"),
+                    @ApiResponse(responseCode = "401", description = "유효하지 않은 인증 토큰"),
+                    @ApiResponse(responseCode = "404", description = "해당 투두 항목을 찾을 수 없음"),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+            }
+    )
+    @GetMapping
+    public ResponseEntity<Map<String, List<TodoResponse>>> getTodoList(
+            @RequestHeader("Authorization") String token
+    ) {
+        Long clubUserId = getClubUserIdFromToken(token);
+        Map<String, List<TodoResponse>> todos = todoService.getTodosByStatus(clubUserId);
+        return ResponseEntity.ok(todos);
+    }
+
+    public Long getClubUserIdFromToken(String token) {
+        // 토큰에서 이메일 추출 -> 이메일로 User 조회 -> User의 ID 반환
+        String email = jwtProvider.getUserEmail(token);
+        User user = ((CustomUserDetails) customUserDetailsService.loadUserByUserId(email)).getUser();
+        return user.getId();
+    }
+
 }

--- a/src/main/java/com/cluting/clutingbackend/todo/domain/Todo.java
+++ b/src/main/java/com/cluting/clutingbackend/todo/domain/Todo.java
@@ -6,6 +6,7 @@ import lombok.*;
 
 @Entity
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -23,5 +24,7 @@ public class Todo {
     private String content;
 
     @Column(nullable = true)
-    private Boolean status;
+    @Builder.Default
+    private Boolean status = false;  //true: 완료, false: 미완료
+
 }

--- a/src/main/java/com/cluting/clutingbackend/todo/dto/TodoRequest.java
+++ b/src/main/java/com/cluting/clutingbackend/todo/dto/TodoRequest.java
@@ -1,7 +1,7 @@
 package com.cluting.clutingbackend.todo.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -9,7 +9,9 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
+@AllArgsConstructor
 // [리크루팅 홈] 투두 작성 시 DTO
 public class TodoRequest {
+    @JsonProperty("content")
     private String content;  //투두 내용
 }

--- a/src/main/java/com/cluting/clutingbackend/todo/dto/TodoRequest.java
+++ b/src/main/java/com/cluting/clutingbackend/todo/dto/TodoRequest.java
@@ -1,0 +1,15 @@
+package com.cluting.clutingbackend.todo.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+// [리크루팅 홈] 투두 작성 시 DTO
+public class TodoRequest {
+    private String content;  //투두 내용
+}

--- a/src/main/java/com/cluting/clutingbackend/todo/dto/TodoResponse.java
+++ b/src/main/java/com/cluting/clutingbackend/todo/dto/TodoResponse.java
@@ -1,0 +1,20 @@
+package com.cluting.clutingbackend.todo.dto;
+
+import com.cluting.clutingbackend.todo.domain.Todo;
+import lombok.Getter;
+
+@Getter
+// [리크루팅 홈] 투두 Response DTO
+public class TodoResponse {
+    private Long id;  // 투두 아이디
+    private String content;  // 투두 내용
+    private Boolean status; // 투두 상태(true:완료, false:미완료)
+
+    public static TodoResponse fromEntity(Todo todo) {
+        TodoResponse response = new TodoResponse();
+        response.id = todo.getId();
+        response.content = todo.getContent();
+        response.status = todo.getStatus();
+        return response;
+    }
+}

--- a/src/main/java/com/cluting/clutingbackend/todo/repository/TodoRepository.java
+++ b/src/main/java/com/cluting/clutingbackend/todo/repository/TodoRepository.java
@@ -6,10 +6,18 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface TodoRepository extends JpaRepository<Todo, Long> {
     // [리크루팅 홈] 투두 리스트 가져오기
     @Query("SELECT t FROM Todo t WHERE t.user.id = :userId")
     List<Todo> findTodosByUserId(Long userId);
+
+    // [리크루팅 홈] 투두 리스트(완료, 미완료 구분) 가져오기
+    List<Todo> findByUserIdAndStatus(Long userId, Boolean status);
+
+    // [리크루팅 홈] 특정 투두 가져오기(삭제, 수정 위함)
+    Optional<Todo> findByIdAndUserId(Long id, Long userId);
+
 }

--- a/src/main/java/com/cluting/clutingbackend/todo/repository/TodoRepository.java
+++ b/src/main/java/com/cluting/clutingbackend/todo/repository/TodoRepository.java
@@ -2,8 +2,14 @@ package com.cluting.clutingbackend.todo.repository;
 
 import com.cluting.clutingbackend.todo.domain.Todo;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface TodoRepository extends JpaRepository<Todo, Long> {
+    // [리크루팅 홈] 투두 리스트 가져오기
+    @Query("SELECT t FROM Todo t WHERE t.user.id = :userId")
+    List<Todo> findTodosByUserId(Long userId);
 }

--- a/src/main/java/com/cluting/clutingbackend/todo/service/TodoService.java
+++ b/src/main/java/com/cluting/clutingbackend/todo/service/TodoService.java
@@ -1,11 +1,80 @@
 package com.cluting.clutingbackend.todo.service;
 
+import com.cluting.clutingbackend.todo.domain.Todo;
+import com.cluting.clutingbackend.todo.dto.TodoRequest;
+import com.cluting.clutingbackend.todo.dto.TodoResponse;
 import com.cluting.clutingbackend.todo.repository.TodoRepository;
+import com.cluting.clutingbackend.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class TodoService {
     private final TodoRepository todoRepository;
+    private final UserRepository userRepository;
+
+    // [리크루팅 홈] 투두 작성하기
+    public TodoResponse createTodo(Long clubUserId, TodoRequest request) {
+        var user = userRepository.findById(clubUserId)
+                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 인증 토큰"));
+
+        Todo todo = Todo.builder()
+                .user(user)
+                .content(request.getContent())
+                .status(false)
+                .build();
+
+        return TodoResponse.fromEntity(todoRepository.save(todo));
+    }
+
+    // [리크루팅 홈] 투두 삭제하기
+    public void deleteTodo(Long clubUserId, Long todoId) {
+        Todo todo = todoRepository.findByIdAndUserId(todoId, clubUserId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 투두 항목을 찾을 수 없음"));
+        todoRepository.delete(todo);
+    }
+
+    // [리크루팅 홈] 투두 완료 상태 바꾸기
+    public void toggleTodoStatus(Long clubUserId, Long todoId) {
+        Todo todo = todoRepository.findByIdAndUserId(todoId, clubUserId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 투두 항목을 찾을 수 없음"));
+        todo.setStatus(!todo.getStatus());
+        todoRepository.save(todo);
+    }
+
+    // [리크루팅 홈] 투두 내용 변경하기
+    public void updateTodoContent(Long clubUserId, Long todoId, String updatedContent) {
+        Todo todo = todoRepository.findByIdAndUserId(todoId, clubUserId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 투두 항목을 찾을 수 없음"));
+        todo.setContent(updatedContent);
+        todoRepository.save(todo);
+    }
+
+    // [리크루팅 홈] 투두 리스트 완료/미완료 분리해서 가져오기
+    public Map<String, List<TodoResponse>> getTodosByStatus(Long clubUserId) {
+        // 미완료 리스트
+        List<TodoResponse> incompleteTodos = todoRepository.findByUserIdAndStatus(clubUserId, false)
+                .stream()
+                .map(TodoResponse::fromEntity)
+                .collect(Collectors.toList());
+
+        // 완료 리스트
+        List<TodoResponse> completeTodos = todoRepository.findByUserIdAndStatus(clubUserId, true)
+                .stream()
+                .map(TodoResponse::fromEntity)
+                .collect(Collectors.toList());
+
+        // 결과를 Map으로 반환
+        Map<String, List<TodoResponse>> todos = new HashMap<>();
+        todos.put("미완료 리스트", incompleteTodos);
+        todos.put("완료 리스트", completeTodos);
+
+        return todos;
+    }
 }

--- a/src/main/java/com/cluting/clutingbackend/user/service/UserService.java
+++ b/src/main/java/com/cluting/clutingbackend/user/service/UserService.java
@@ -1,5 +1,12 @@
 package com.cluting.clutingbackend.user.service;
 
+import com.cluting.clutingbackend.admininvite.domain.AdminInvite;
+import com.cluting.clutingbackend.admininvite.repository.AdminInviteRepository;
+import com.cluting.clutingbackend.admininvite.repository.TempUserRepository;
+import com.cluting.clutingbackend.club.domain.Club;
+import com.cluting.clutingbackend.clubuser.domain.ClubUser;
+import com.cluting.clutingbackend.clubuser.repository.ClubUserRepository;
+import com.cluting.clutingbackend.global.enums.ClubRole;
 import com.cluting.clutingbackend.user.domain.User;
 import com.cluting.clutingbackend.user.dto.response.UserResponseDto;
 import com.cluting.clutingbackend.user.dto.request.UserSignInRequestDto;
@@ -16,6 +23,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.time.LocalDateTime;
+
 @Service
 @RequiredArgsConstructor
 public class UserService {
@@ -23,6 +32,10 @@ public class UserService {
     private final PasswordEncoder passwordEncoder;
     private final JwtProvider jwtProvider;
     private final RedisUtil redisUtil;
+    // 비회원 운영진 초대를 위해 아래 repo 추가
+    private final TempUserRepository tempUserRepository;
+    private final ClubUserRepository clubUserRepository;
+    private final AdminInviteRepository adminInviteRepository;
 
     @Transactional
     public UserResponseDto signUp(UserSignUpRequestDto userSignUpRequestDto) {
@@ -43,6 +56,36 @@ public class UserService {
         User user = userRepository.save(
                 userSignUpRequestDto.toEntity(passwordEncoder.encode(userSignUpRequestDto.getPassword()))
         );
+
+        // [운영진 초대] 비회원 운영진 초대 시, 회원가입 후 운영진으로 등록되게 하기 위함.
+        tempUserRepository.findByEmail(user.getEmail()).ifPresent(tempUser -> {
+            AdminInvite adminInvite = tempUser.getInvite();
+            Club club = adminInvite.getClub();
+
+            if (!adminInvite.getIsUsed() && adminInvite.getExpirationDate().isAfter(LocalDateTime.now())) {
+                ClubUser clubUser = ClubUser.builder()
+                        .user(user)
+                        .club(club)
+                        .role(ClubRole.STAFF)
+                        .generation(club.getRecruits().stream()
+                                .filter(recruit -> !recruit.getIsDone())
+                                .findFirst()
+                                .orElseThrow(() -> new IllegalArgumentException("Active recruitment not found"))
+                                .getGeneration()
+                        )
+                        .build();
+                clubUserRepository.save(clubUser);
+
+                // 초대 처리 완료
+                adminInvite.setIsUsed(true);
+                adminInviteRepository.save(adminInvite);
+            }
+
+            // TempUser 삭제
+            tempUserRepository.delete(tempUser);
+        });
+
+
         return UserResponseDto.toDto(user);
     }
 


### PR DESCRIPTION
## 📝작업 내용

### 완료한 기능
- [x] [리크루팅 홈] 불러오기
- [x] [리크루팅 홈] 투두 기능
- [x] [리크루팅 홈] 운영진 초대 기능
- [x] [계획하기] 불러오기
- [x] [계획하기] 완료하기
- [x] [서류 평가하기] 평가전 지원서 불러오기

### 수정한 도메인
- [x] Part -> Group 이름 변경, int형에서 integer로 변경 (null 값 처리를 위함.)
- [x] Application : part -> recruit_group 이름 변경 (group 예약어 이슈)
- [x] Interview : part -> recruit_group 이름 변경 (group 예약어 이슈)
- [x] DocumentCriteria : part_id -> group_id
- [x] DocumentEvaluator : part_id -> group_id
- [x] DocumentQuestion : part_id -> group_id
- [x] InterviewEvaluator : part_id -> group_id
- [x] TelentProfile : part_id -> group_id
- [x] Recruit : 기수, 장소 추가


## 💬리뷰 요구사항(선택)

> Group 테이블명 더 편하신 걸로 바꾸셔도 좋을 거 같습니다! group은 예약어라 불가능합니다!
