### PR TITLE
[1차 MVP] 홈화면, 서류 평가하기-(1)서류 평가 준비하기

### DIFF
--- a/src/main/java/com/cluting/clutingbackend/application/repository/ApplicationRepository.java
+++ b/src/main/java/com/cluting/clutingbackend/application/repository/ApplicationRepository.java
@@ -4,6 +4,9 @@ import com.cluting.clutingbackend.application.domain.Application;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface ApplicationRepository extends JpaRepository<Application, Long> {
+    List<Application> findByRecruit_Id(Long recruitId);
 }

--- a/src/main/java/com/cluting/clutingbackend/club/controller/ClubController.java
+++ b/src/main/java/com/cluting/clutingbackend/club/controller/ClubController.java
@@ -1,11 +1,89 @@
 package com.cluting.clutingbackend.club.controller;
 
+import com.cluting.clutingbackend.club.dto.request.ClubRegisterRequestDto;
+import com.cluting.clutingbackend.club.dto.response.ClubResponseDto;
 import com.cluting.clutingbackend.club.service.ClubService;
+import com.cluting.clutingbackend.global.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @RestController
+@RequestMapping("/api/v1/club")
 @RequiredArgsConstructor
 public class ClubController {
     private final ClubService clubService;
+
+    @Operation(description = "동아리 등록 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "동아리 추가 성공"),
+            @ApiResponse(responseCode = "404", description = "동아리 추가 실패"),
+            @ApiResponse(responseCode = "500", description = "Internal server error")})
+    @PostMapping(value = "/register", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    @ResponseStatus(value = HttpStatus.CREATED)
+    public ClubResponseDto register(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @ModelAttribute ClubRegisterRequestDto clubCreateRequestDto,
+            @RequestPart(value = "profile", required = false) MultipartFile profile) {
+        return clubService.registerClub(userDetails.getUser(), clubCreateRequestDto, profile);
+    }
+
+    // 홈페이지
+    @Operation(description = "가장 인기있는 동아리 3개 조회 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "동아리 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "동아리 조회 실패"),
+            @ApiResponse(responseCode = "500", description = "Internal server error")})
+    @GetMapping("/popular")
+    @ResponseStatus(value = HttpStatus.OK)
+    public List<ClubResponseDto> popular(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        return clubService.popular(userDetails.getUser());
+    }
+
+    @Operation(description = "ID로 동아리 단일 조회 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "동아리 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "동아리 조회 실패"),
+            @ApiResponse(responseCode = "500", description = "Internal server error")})
+    @GetMapping("/{clubId}")
+    @ResponseStatus(value = HttpStatus.OK)
+    public ClubResponseDto findById(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable("clubId") Long clubId) {
+        return clubService.findById(clubId);
+    }
+
+    @Operation(description = "로그인 된 사용자가 가입한 동아리 목록 조회 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "동아리 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "동아리 조회 실패"),
+            @ApiResponse(responseCode = "500", description = "Internal server error")})
+    @GetMapping("/user")
+    @ResponseStatus(value = HttpStatus.OK)
+    public List<ClubResponseDto> findByUser(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        return clubService.findByUser(userDetails.getUser());
+    }
+
+    @Operation(description = "동아리 리크루팅 시작 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "동아리 리크루팅 시작 성공"),
+            @ApiResponse(responseCode = "404", description = "동아리 리크루팅 시작 실패"),
+            @ApiResponse(responseCode = "500", description = "Internal server error")})
+    @PutMapping("/start/{clubId}")
+    @ResponseStatus(value = HttpStatus.OK)
+    public ClubResponseDto recruitingStart(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable("clubId") Long clubId) {
+        return clubService.recruitingStart(userDetails.getUser(), clubId);
+    }
 }

--- a/src/main/java/com/cluting/clutingbackend/club/dto/request/ClubRegisterRequestDto.java
+++ b/src/main/java/com/cluting/clutingbackend/club/dto/request/ClubRegisterRequestDto.java
@@ -1,0 +1,31 @@
+package com.cluting.clutingbackend.club.dto.request;
+
+import com.cluting.clutingbackend.club.domain.Club;
+import com.cluting.clutingbackend.global.enums.Category;
+import com.cluting.clutingbackend.global.enums.ClubType;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class ClubRegisterRequestDto {
+    private String name;
+    private String description;
+    private Category category;
+    private ClubType type;
+    private List<String> keyword;
+
+    public Club toEntity(String imageUrl) {
+        return Club.builder()
+                .name(name)
+                .description(description)
+                .profile(imageUrl)
+                .category(category)
+                .type(type)
+                .keyword((keyword != null) ? String.join(":::", keyword) : "")
+                .isRecruiting(false)
+                .build();
+    }
+}

--- a/src/main/java/com/cluting/clutingbackend/club/dto/response/ClubRecruitResponseDto.java
+++ b/src/main/java/com/cluting/clutingbackend/club/dto/response/ClubRecruitResponseDto.java
@@ -1,0 +1,46 @@
+package com.cluting.clutingbackend.club.dto.response;
+
+import com.cluting.clutingbackend.global.enums.CurrentStage;
+import com.cluting.clutingbackend.recruit.domain.Recruit;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ClubRecruitResponseDto {
+    private Long id;
+    private String title;
+    private String description;
+    private String image;
+    private Boolean isDone;
+    private String caution;
+    private LocalDateTime deadLine;
+    private CurrentStage currentStage;
+    private Boolean isInterview;
+    private String applicationTitle;
+    private Boolean isRequiredPortfolio;
+    private Integer interviewerCount;
+    private Integer intervieweeCount;
+    private Integer interviewDuration;
+
+    public static ClubRecruitResponseDto toDto(Recruit entity) {
+        return ClubRecruitResponseDto.builder()
+                .id(entity.getId())
+                .title(entity.getTitle())
+                .description(entity.getDescription())
+                .image(entity.getImage())
+                .isDone(entity.getIsDone())
+                .caution(entity.getCaution())
+                .deadLine(entity.getDeadLine())
+                .currentStage(entity.getCurrentStage())
+                .isInterview(entity.getIsInterview())
+                .applicationTitle(entity.getApplicationTitle())
+                .isRequiredPortfolio(entity.getIsRequiredPortfolio())
+                .interviewerCount(entity.getInterviewerCount())
+                .intervieweeCount(entity.getIntervieweeCount())
+                .interviewDuration(entity.getInterviewDuration())
+                .build();
+    }
+}

--- a/src/main/java/com/cluting/clutingbackend/club/dto/response/ClubResponseDto.java
+++ b/src/main/java/com/cluting/clutingbackend/club/dto/response/ClubResponseDto.java
@@ -1,0 +1,39 @@
+package com.cluting.clutingbackend.club.dto.response;
+
+import com.cluting.clutingbackend.club.domain.Club;
+import com.cluting.clutingbackend.global.enums.Category;
+import com.cluting.clutingbackend.global.enums.ClubType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+@Getter
+@Builder
+public class ClubResponseDto {
+    private Long id;
+    private List<ClubRecruitResponseDto> recruits;
+    private String name;
+    private String description;
+    private String profile;
+    private Category category;
+    private ClubType type;
+    private List<String> keyword;
+    private Boolean isRecruiting;
+
+    public static ClubResponseDto toDto(Club entity) {
+        return ClubResponseDto.builder()
+                .id(entity.getId())
+                .recruits(entity.getRecruits() != null ? entity.getRecruits().stream().map(ClubRecruitResponseDto::toDto).toList() : Collections.emptyList())
+                .name(entity.getName())
+                .description(entity.getDescription())
+                .profile(entity.getProfile())
+                .category(entity.getCategory())
+                .type(entity.getType())
+                .keyword(Arrays.stream(entity.getKeyword().split(":::")).toList())
+                .isRecruiting(entity.getIsRecruiting())
+                .build();
+    }
+}

--- a/src/main/java/com/cluting/clutingbackend/club/repository/ClubRepository.java
+++ b/src/main/java/com/cluting/clutingbackend/club/repository/ClubRepository.java
@@ -2,8 +2,17 @@ package com.cluting.clutingbackend.club.repository;
 
 import com.cluting.clutingbackend.club.domain.Club;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface ClubRepository extends JpaRepository<Club, Long> {
+
+    @Query(value = "" +
+            "SELECT * " +
+            "FROM tb_club " +
+            "ORDER BY RAND() LIMIT 3", nativeQuery = true)
+    List<Club> findPopular();
 }

--- a/src/main/java/com/cluting/clutingbackend/club/service/ClubService.java
+++ b/src/main/java/com/cluting/clutingbackend/club/service/ClubService.java
@@ -1,11 +1,76 @@
 package com.cluting.clutingbackend.club.service;
 
+import com.cluting.clutingbackend.club.domain.Club;
+import com.cluting.clutingbackend.club.dto.request.ClubRegisterRequestDto;
+import com.cluting.clutingbackend.club.dto.response.ClubResponseDto;
 import com.cluting.clutingbackend.club.repository.ClubRepository;
+import com.cluting.clutingbackend.clubuser.domain.ClubUser;
+import com.cluting.clutingbackend.clubuser.repository.ClubUserRepository;
+import com.cluting.clutingbackend.global.s3.AwsS3Service;
+import com.cluting.clutingbackend.global.util.StaticValue;
+import com.cluting.clutingbackend.user.domain.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 public class ClubService {
     private final ClubRepository clubRepository;
+    private final ClubUserRepository clubUserRepository;
+    private final AwsS3Service awsS3Service;
+
+    // 가장 인기있는 동아리 조회
+    @Transactional(readOnly = true)
+    public List<ClubResponseDto> popular(User user) {
+        return clubRepository.findPopular().stream().map(ClubResponseDto::toDto).toList();
+    }
+
+    // 동아리 등록
+    @Transactional
+    public ClubResponseDto registerClub(User user, ClubRegisterRequestDto clubRegisterRequestDto, MultipartFile profile) {
+        String imageUrl;
+        if (profile == null) imageUrl = StaticValue.profileImage;
+        else imageUrl = awsS3Service.uploadFile(profile);
+
+        return ClubResponseDto.toDto(clubRepository.save(clubRegisterRequestDto.toEntity(imageUrl)));
+    }
+
+    // 동아리 id로 조회
+    @Transactional(readOnly = true)
+    public ClubResponseDto findById(Long clubId) {
+        Club club = clubRepository.findById(clubId)
+                .orElseThrow(
+                        () -> new ResponseStatusException(
+                                HttpStatus.BAD_REQUEST, "존재하지 않는 동아리 입니다."
+                        )
+                );
+        return ClubResponseDto.toDto(club);
+    }
+
+    // 로그인한 사용자가 가입한 동아리 목록 조회
+    @Transactional(readOnly = true)
+    public List<ClubResponseDto> findByUser(User user) {
+        List<Club> clubs = clubUserRepository.findByUser_Id(user.getId()).stream().map(ClubUser::getClub).toList();
+        return clubs.stream().map(ClubResponseDto::toDto).toList();
+    }
+
+    // 동아리 리크루팅 시작
+    @Transactional
+    public ClubResponseDto recruitingStart(User user, Long clubId) {
+        Club club = clubRepository.findById(clubId)
+                .orElseThrow(
+                        () -> new ResponseStatusException(
+                                HttpStatus.BAD_REQUEST, "존재하지 않는 동아리 입니다."
+                        )
+                );
+        club.setIsRecruiting(true);
+        return ClubResponseDto.toDto(clubRepository.save(club));
+    }
 }

--- a/src/main/java/com/cluting/clutingbackend/clubuser/controller/ClubUserController.java
+++ b/src/main/java/com/cluting/clutingbackend/clubuser/controller/ClubUserController.java
@@ -1,11 +1,31 @@
 package com.cluting.clutingbackend.clubuser.controller;
 
+import com.cluting.clutingbackend.clubuser.dto.response.ClubUserResponseDto;
 import com.cluting.clutingbackend.clubuser.service.ClubUserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
+@RequestMapping("/api/v1/clubuser")
 @RequiredArgsConstructor
 public class ClubUserController {
     private final ClubUserService clubUserService;
+
+    @Operation(description = "동아리 ID로 모든 운영진 목록 조회 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "운영진 목록 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "운영진 목록 조회 실패"),
+            @ApiResponse(responseCode = "500", description = "Internal server error")})
+    @GetMapping("/{clubId}")
+    @ResponseStatus(value = HttpStatus.OK)
+    public List<ClubUserResponseDto> findPosts(
+            @PathVariable("clubId") Long clubId) {
+        return clubUserService.findAll(clubId);
+    }
 }

--- a/src/main/java/com/cluting/clutingbackend/clubuser/dto/response/ClubUserResponseDto.java
+++ b/src/main/java/com/cluting/clutingbackend/clubuser/dto/response/ClubUserResponseDto.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 @Getter
 @Builder
 public class ClubUserResponseDto {
-    private Long clubUserId;
+    private Long id;
     private Long userId;
     private Long clubId;
     private ClubRole role;
@@ -17,7 +17,7 @@ public class ClubUserResponseDto {
 
     public static ClubUserResponseDto toDto(ClubUser entity) {
         return ClubUserResponseDto.builder()
-                .clubUserId(entity.getId())
+                .id(entity.getId())
                 .userId(entity.getUser().getId())
                 .clubId(entity.getClub().getId())
                 .role(entity.getRole())

--- a/src/main/java/com/cluting/clutingbackend/clubuser/repository/ClubUserRepository.java
+++ b/src/main/java/com/cluting/clutingbackend/clubuser/repository/ClubUserRepository.java
@@ -9,4 +9,6 @@ import java.util.List;
 @Repository
 public interface ClubUserRepository extends JpaRepository<ClubUser, Long> {
     List<ClubUser> findByUser_Id(Long userId);
+
+    List<ClubUser> findByClub_Id(Long clubId);
 }

--- a/src/main/java/com/cluting/clutingbackend/clubuser/repository/ClubUserRepository.java
+++ b/src/main/java/com/cluting/clutingbackend/clubuser/repository/ClubUserRepository.java
@@ -4,6 +4,9 @@ import com.cluting.clutingbackend.clubuser.domain.ClubUser;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface ClubUserRepository extends JpaRepository<ClubUser, Long> {
+    List<ClubUser> findByUser_Id(Long userId);
 }

--- a/src/main/java/com/cluting/clutingbackend/clubuser/service/ClubUserService.java
+++ b/src/main/java/com/cluting/clutingbackend/clubuser/service/ClubUserService.java
@@ -1,11 +1,20 @@
 package com.cluting.clutingbackend.clubuser.service;
 
+import com.cluting.clutingbackend.clubuser.dto.response.ClubUserResponseDto;
 import com.cluting.clutingbackend.clubuser.repository.ClubUserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class ClubUserService {
     private final ClubUserRepository clubUserRepository;
+
+    @Transactional(readOnly = true)
+    public List<ClubUserResponseDto> findAll(Long clubId) {
+        return clubUserRepository.findByClub_Id(clubId).stream().map(ClubUserResponseDto::toDto).toList();
+    }
 }

--- a/src/main/java/com/cluting/clutingbackend/global/enums/SortType.java
+++ b/src/main/java/com/cluting/clutingbackend/global/enums/SortType.java
@@ -1,0 +1,14 @@
+package com.cluting.clutingbackend.global.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SortType {
+    DEADLINE("마감임박순"),
+    NEWEST("최신순"),
+    OLDEST("오래된순");
+
+    private final String description;
+}

--- a/src/main/java/com/cluting/clutingbackend/global/enums/Stage.java
+++ b/src/main/java/com/cluting/clutingbackend/global/enums/Stage.java
@@ -1,0 +1,17 @@
+package com.cluting.clutingbackend.global.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Stage {
+    BEFORE("평가 전"),
+    ING("평가 중"),
+    AFTER("평가 완료"),
+
+    READABLE("열람 가능"),
+    EDITABLE("수정 가능");
+
+    private final String description;
+}

--- a/src/main/java/com/cluting/clutingbackend/global/s3/AwsS3Service.java
+++ b/src/main/java/com/cluting/clutingbackend/global/s3/AwsS3Service.java
@@ -1,0 +1,57 @@
+package com.cluting.clutingbackend.global.s3;
+
+import com.cluting.clutingbackend.global.util.S3BucketUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetUrlRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.IOException;
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+public class AwsS3Service {
+    private final S3Client s3Client;
+
+    @Value("${spring.cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    public String uploadFile(MultipartFile multipartFile) {
+
+        if(multipartFile.isEmpty()) {
+            return "";
+        }
+
+        String fileName = getFileName(multipartFile);
+
+        try {
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                    .bucket(bucketName)
+                    .contentType(multipartFile.getContentType())
+                    .contentLength(multipartFile.getSize())
+                    .key(fileName)
+                    .build();
+
+            RequestBody requestBody = RequestBody.fromBytes(multipartFile.getBytes());
+            s3Client.putObject(putObjectRequest, requestBody);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        GetUrlRequest getUrlRequest = GetUrlRequest.builder()
+                .bucket(bucketName)
+                .key(fileName)
+                .build();
+
+        return s3Client.utilities().getUrl(getUrlRequest).toString();
+    }
+
+    public String getFileName(MultipartFile multipartFile) {
+        if(multipartFile.isEmpty()) return "";
+        return S3BucketUtil.buildFileName(Objects.requireNonNull(multipartFile.getOriginalFilename()));
+    }
+}

--- a/src/main/java/com/cluting/clutingbackend/global/util/StaticValue.java
+++ b/src/main/java/com/cluting/clutingbackend/global/util/StaticValue.java
@@ -7,4 +7,7 @@ public class StaticValue {
 
     // page
     public static final Integer PAGE_DEFAULT_SIZE = 12;
+
+    // image
+    public static final String profileImage = "https://cluting.s3.ap-northeast-2.amazonaws.com/default.png";
 }

--- a/src/main/java/com/cluting/clutingbackend/plan/controller/GroupController.java
+++ b/src/main/java/com/cluting/clutingbackend/plan/controller/GroupController.java
@@ -1,0 +1,11 @@
+package com.cluting.clutingbackend.plan.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/group")
+@RequiredArgsConstructor
+public class GroupController {
+}

--- a/src/main/java/com/cluting/clutingbackend/plan/domain/DocumentCriteria.java
+++ b/src/main/java/com/cluting/clutingbackend/plan/domain/DocumentCriteria.java
@@ -1,0 +1,32 @@
+package com.cluting.clutingbackend.plan.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@Builder
+@Table(name = "tb_document_criteria")
+public class DocumentCriteria {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private String name;
+
+    @Lob
+    @Column(length = 2000)
+    private String content;
+
+    @Column
+    private Integer score;
+
+    @ManyToOne
+    @JoinColumn(name = "group_id", nullable = false)
+    private Group group;
+}

--- a/src/main/java/com/cluting/clutingbackend/plan/domain/DocumentEvaluator.java
+++ b/src/main/java/com/cluting/clutingbackend/plan/domain/DocumentEvaluator.java
@@ -1,0 +1,63 @@
+package com.cluting.clutingbackend.plan.domain;
+
+import com.cluting.clutingbackend.application.domain.Application;
+import com.cluting.clutingbackend.clubuser.domain.ClubUser;
+import com.cluting.clutingbackend.global.enums.Stage;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Builder
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "tb_document_evaluator")
+public class DocumentEvaluator {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "clubUser_id", nullable = true)
+    private ClubUser clubUser;
+
+    @ManyToOne
+    @JoinColumn(name = "application_id", nullable = false)
+    private Application application;
+
+    @ManyToOne
+    @JoinColumn(name = "group_id", nullable = true)
+    private Group group;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = true)
+    @Builder.Default
+    private Stage stage = Stage.BEFORE;
+
+    @Column
+    private Integer score; // 평가 점수
+
+    @Column
+    private String comment; // 평가 코멘트
+
+    public static DocumentEvaluator of(
+            ClubUser clubUser,
+            Application application,
+            Group group,
+            Stage stage,
+            Integer score,
+            String comment
+    ) {
+        return DocumentEvaluator.builder()
+                .clubUser(clubUser)
+                .application(application)
+                .group(group)
+                .stage(stage)
+                .score(score)
+                .comment(comment)
+                .build();
+    }
+
+}

--- a/src/main/java/com/cluting/clutingbackend/plan/domain/Group.java
+++ b/src/main/java/com/cluting/clutingbackend/plan/domain/Group.java
@@ -3,17 +3,15 @@ package com.cluting.clutingbackend.plan.domain;
 
 import com.cluting.clutingbackend.recruit.domain.Recruit;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 @Entity
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 @Getter
 @Setter
-@Table(name = "recruit_group")
+@Table(name = "tb_group")
 public class Group {
 
     @Id
@@ -39,4 +37,21 @@ public class Group {
     @Column(nullable = true)
     private String warning;
 
+    public static Group of(
+            Recruit recruit,
+            String name,
+            Integer numDoc,
+            Integer numFinal,
+            Integer numRecruit,
+            String warning
+    ) {
+        return Group.builder()
+                .recruit(recruit)
+                .name(name)
+                .numDoc(numDoc)
+                .numFinal(numFinal)
+                .numRecruit(numRecruit)
+                .warning(warning)
+                .build();
+    }
 }

--- a/src/main/java/com/cluting/clutingbackend/plan/domain/Group.java
+++ b/src/main/java/com/cluting/clutingbackend/plan/domain/Group.java
@@ -1,0 +1,42 @@
+package com.cluting.clutingbackend.plan.domain;
+
+
+import com.cluting.clutingbackend.recruit.domain.Recruit;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@Table(name = "recruit_group")
+public class Group {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "recruit_id", nullable = false)
+    private Recruit recruit;
+
+    @Column(nullable = true)
+    private String name;
+
+    @Column(nullable = true)
+    private Integer numDoc;
+
+    @Column(nullable = true)
+    private Integer numFinal;
+
+    @Column(nullable = true)
+    private Integer numRecruit;
+
+    @Column(nullable = true)
+    private String warning;
+
+}

--- a/src/main/java/com/cluting/clutingbackend/plan/repository/DocumentCriteriaRepository.java
+++ b/src/main/java/com/cluting/clutingbackend/plan/repository/DocumentCriteriaRepository.java
@@ -1,0 +1,9 @@
+package com.cluting.clutingbackend.plan.repository;
+
+import com.cluting.clutingbackend.plan.domain.DocumentCriteria;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DocumentCriteriaRepository extends JpaRepository<DocumentCriteria, Long> {
+}

--- a/src/main/java/com/cluting/clutingbackend/plan/repository/DocumentEvaluatorRepository.java
+++ b/src/main/java/com/cluting/clutingbackend/plan/repository/DocumentEvaluatorRepository.java
@@ -1,0 +1,9 @@
+package com.cluting.clutingbackend.plan.repository;
+
+import com.cluting.clutingbackend.plan.domain.DocumentEvaluator;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DocumentEvaluatorRepository extends JpaRepository<DocumentEvaluator, Long> {
+}

--- a/src/main/java/com/cluting/clutingbackend/plan/repository/GroupRepository.java
+++ b/src/main/java/com/cluting/clutingbackend/plan/repository/GroupRepository.java
@@ -1,0 +1,12 @@
+package com.cluting.clutingbackend.plan.repository;
+
+import com.cluting.clutingbackend.plan.domain.Group;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface GroupRepository extends JpaRepository<Group, Long> {
+    List<Group> findByRecruit_Id(Long recruitId);
+}

--- a/src/main/java/com/cluting/clutingbackend/plan/service/GroupService.java
+++ b/src/main/java/com/cluting/clutingbackend/plan/service/GroupService.java
@@ -1,0 +1,11 @@
+package com.cluting.clutingbackend.plan.service;
+
+import com.cluting.clutingbackend.plan.repository.GroupRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GroupService {
+    private final GroupRepository groupRepository;
+}

--- a/src/main/java/com/cluting/clutingbackend/recruit/controller/RecruitController.java
+++ b/src/main/java/com/cluting/clutingbackend/recruit/controller/RecruitController.java
@@ -3,6 +3,7 @@ package com.cluting.clutingbackend.recruit.controller;
 import com.cluting.clutingbackend.global.enums.Category;
 import com.cluting.clutingbackend.global.enums.ClubType;
 import com.cluting.clutingbackend.global.enums.SortType;
+import com.cluting.clutingbackend.recruit.dto.response.RecruitNumResponseDto;
 import com.cluting.clutingbackend.recruit.dto.response.RecruitResponseDto;
 import com.cluting.clutingbackend.recruit.dto.response.RecruitsResponseDto;
 import com.cluting.clutingbackend.recruit.service.RecruitService;
@@ -46,9 +47,29 @@ public class RecruitController {
         return recruitService.findById(recruitId);
     }
 
-    //TODO 모집공고의 각 파트의 지원자 수, 전체 지원자 수
+    @Operation(description = "모집 공고에 지원한 지원자 수 조회 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "404", description = "조회 실패"),
+            @ApiResponse(responseCode = "500", description = "Internal server error")})
+    @GetMapping("/{recruitId}")
+    @ResponseStatus(value = HttpStatus.OK)
+    public RecruitNumResponseDto findAppliedNum(
+            @PathVariable("recruitId") Long recruitId) {
+        return recruitService.findAppliedNum(recruitId);
+    }
 
-    //TODO 이전 과정에서 설정한 서류 합격자 수 목록
+    @Operation(description = "이전 과정에서 설정한 서류 합격자 수 목록 조회 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "404", description = "조회 실패"),
+            @ApiResponse(responseCode = "500", description = "Internal server error")})
+    @GetMapping("/{recruitId}")
+    @ResponseStatus(value = HttpStatus.OK)
+    public RecruitNumResponseDto findDocPassNum(
+            @PathVariable("recruitId") Long recruitId) {
+        return recruitService.findDocPassNum(recruitId);
+    }
 
     //TODO 서류 평가 준비하기 설정 (공통 그룹 처리 필요)
 }

--- a/src/main/java/com/cluting/clutingbackend/recruit/controller/RecruitController.java
+++ b/src/main/java/com/cluting/clutingbackend/recruit/controller/RecruitController.java
@@ -3,15 +3,18 @@ package com.cluting.clutingbackend.recruit.controller;
 import com.cluting.clutingbackend.global.enums.Category;
 import com.cluting.clutingbackend.global.enums.ClubType;
 import com.cluting.clutingbackend.global.enums.SortType;
+import com.cluting.clutingbackend.global.security.CustomUserDetails;
+import com.cluting.clutingbackend.recruit.dto.request.RecruitDocSetRequestDto;
+import com.cluting.clutingbackend.recruit.dto.response.RecruitDocPrepSavedResponseDto;
 import com.cluting.clutingbackend.recruit.dto.response.RecruitNumResponseDto;
 import com.cluting.clutingbackend.recruit.dto.response.RecruitResponseDto;
 import com.cluting.clutingbackend.recruit.dto.response.RecruitsResponseDto;
 import com.cluting.clutingbackend.recruit.service.RecruitService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -20,11 +23,15 @@ import org.springframework.web.bind.annotation.*;
 public class RecruitController {
     private final RecruitService recruitService;
 
-    @Operation(description = "홈화면 동아리 리스트 조회 API")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "동아리 조회 성공"),
-            @ApiResponse(responseCode = "404", description = "동아리 조회 실패"),
-            @ApiResponse(responseCode = "500", description = "Internal server error")})
+    @Operation(
+            summary = "홈화면 동아리 리스트 조회",
+            description = "홈화면 동아리 리스트를 조회합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "홈화면 동아리 리스트 조회되었습니다."),
+                    @ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.")
+            }
+    )
     @GetMapping("/list")
     @ResponseStatus(value = HttpStatus.OK)
     public RecruitsResponseDto findPosts(
@@ -35,11 +42,15 @@ public class RecruitController {
         return recruitService.findAll(pageNum, sortType, clubType, category);
     }
 
-    @Operation(description = "ID로 리크루팅 단일 조회 API")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "리크루팅 조회 성공"),
-            @ApiResponse(responseCode = "404", description = "리크루팅 조회 실패"),
-            @ApiResponse(responseCode = "500", description = "Internal server error")})
+    @Operation(
+            summary = "ID로 리크루팅 단일 조회",
+            description = "ID로 리크루팅 단일 조회합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "ID로 리크루팅 단일 조회되었습니다."),
+                    @ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.")
+            }
+    )
     @GetMapping("/{recruitId}")
     @ResponseStatus(value = HttpStatus.OK)
     public RecruitResponseDto findPosts(
@@ -47,29 +58,52 @@ public class RecruitController {
         return recruitService.findById(recruitId);
     }
 
-    @Operation(description = "모집 공고에 지원한 지원자 수 조회 API")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "조회 성공"),
-            @ApiResponse(responseCode = "404", description = "조회 실패"),
-            @ApiResponse(responseCode = "500", description = "Internal server error")})
-    @GetMapping("/{recruitId}")
+    @Operation(
+            summary = "모집 공고에 지원한 지원자 수 조회",
+            description = "모집 공고에 지원한 지원자 수 조회합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "모집 공고에 지원한 지원자 수 조회되었습니다."),
+                    @ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.")
+            }
+    )
+    @GetMapping("/apply/{recruitId}")
     @ResponseStatus(value = HttpStatus.OK)
     public RecruitNumResponseDto findAppliedNum(
             @PathVariable("recruitId") Long recruitId) {
         return recruitService.findAppliedNum(recruitId);
     }
 
-    @Operation(description = "이전 과정에서 설정한 서류 합격자 수 목록 조회 API")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "조회 성공"),
-            @ApiResponse(responseCode = "404", description = "조회 실패"),
-            @ApiResponse(responseCode = "500", description = "Internal server error")})
-    @GetMapping("/{recruitId}")
+    @Operation(
+            summary = "이전 과정에서 설정한 서류 합격자 수 목록 조회",
+            description = "이전 과정에서 설정한 서류 합격자 수 목록 조회합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "이전 과정에서 설정한 서류 합격자 수 목록 조회되었습니다."),
+                    @ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.")
+            }
+    )
+    @GetMapping("/doc/pre/{recruitId}")
     @ResponseStatus(value = HttpStatus.OK)
     public RecruitNumResponseDto findDocPassNum(
             @PathVariable("recruitId") Long recruitId) {
         return recruitService.findDocPassNum(recruitId);
     }
 
-    //TODO 서류 평가 준비하기 설정 (공통 그룹 처리 필요)
+    @Operation(
+            summary = "서류 평가 준비하기 설정 저장",
+            description = "서류 평가 준비하기 설정을 저장합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "201", description = "서류 평가 준비하기 설정이 저장되었습니다."),
+                    @ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.")
+            }
+    )
+    @PostMapping("/doc/pre/{recruitId}")
+    @ResponseStatus(value = HttpStatus.CREATED)
+    public RecruitDocPrepSavedResponseDto saveDocRecruit(
+            @PathVariable("recruitId") Long recruitId,
+            @RequestBody RecruitDocSetRequestDto recruitDocSetRequestDto) {
+        return recruitService.saveDocRecruit(recruitId, recruitDocSetRequestDto);
+    }
 }

--- a/src/main/java/com/cluting/clutingbackend/recruit/controller/RecruitController.java
+++ b/src/main/java/com/cluting/clutingbackend/recruit/controller/RecruitController.java
@@ -3,6 +3,7 @@ package com.cluting.clutingbackend.recruit.controller;
 import com.cluting.clutingbackend.global.enums.Category;
 import com.cluting.clutingbackend.global.enums.ClubType;
 import com.cluting.clutingbackend.global.enums.SortType;
+import com.cluting.clutingbackend.recruit.dto.response.RecruitResponseDto;
 import com.cluting.clutingbackend.recruit.dto.response.RecruitsResponseDto;
 import com.cluting.clutingbackend.recruit.service.RecruitService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -10,10 +11,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -33,5 +31,17 @@ public class RecruitController {
             @RequestParam(value = "clubType", required = false) ClubType clubType, // 연합동아리, 교내동아리
             @RequestParam(value = "fieldType", required = false) Category category) { // 동아리 분류
         return recruitService.findAll(pageNum, sortType, clubType, category);
+    }
+
+    @Operation(description = "ID로 리크루팅 단일 조회 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "리크루팅 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "리크루팅 조회 실패"),
+            @ApiResponse(responseCode = "500", description = "Internal server error")})
+    @GetMapping("/{recruitId}")
+    @ResponseStatus(value = HttpStatus.OK)
+    public RecruitResponseDto findPosts(
+            @PathVariable("recruitId") Long recruitId) {
+        return recruitService.findById(recruitId);
     }
 }

--- a/src/main/java/com/cluting/clutingbackend/recruit/controller/RecruitController.java
+++ b/src/main/java/com/cluting/clutingbackend/recruit/controller/RecruitController.java
@@ -14,6 +14,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
+@RequestMapping("/api/v1/recruit")
 @RequiredArgsConstructor
 public class RecruitController {
     private final RecruitService recruitService;
@@ -44,4 +45,10 @@ public class RecruitController {
             @PathVariable("recruitId") Long recruitId) {
         return recruitService.findById(recruitId);
     }
+
+    //TODO 모집공고의 각 파트의 지원자 수, 전체 지원자 수
+
+    //TODO 이전 과정에서 설정한 서류 합격자 수 목록
+
+    //TODO 서류 평가 준비하기 설정 (공통 그룹 처리 필요)
 }

--- a/src/main/java/com/cluting/clutingbackend/recruit/controller/RecruitController.java
+++ b/src/main/java/com/cluting/clutingbackend/recruit/controller/RecruitController.java
@@ -1,11 +1,37 @@
 package com.cluting.clutingbackend.recruit.controller;
 
+import com.cluting.clutingbackend.global.enums.Category;
+import com.cluting.clutingbackend.global.enums.ClubType;
+import com.cluting.clutingbackend.global.enums.SortType;
+import com.cluting.clutingbackend.recruit.dto.response.RecruitsResponseDto;
 import com.cluting.clutingbackend.recruit.service.RecruitService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
 public class RecruitController {
     private final RecruitService recruitService;
+
+    @Operation(description = "홈화면 동아리 리스트 조회 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "동아리 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "동아리 조회 실패"),
+            @ApiResponse(responseCode = "500", description = "Internal server error")})
+    @GetMapping("/list")
+    @ResponseStatus(value = HttpStatus.OK)
+    public RecruitsResponseDto findPosts(
+            @RequestParam(value = "pageNum", defaultValue = "0") Integer pageNum,
+            @RequestParam(value = "sortType", required = false) SortType sortType, // 마감임박순, 최신순, 오래된 순
+            @RequestParam(value = "clubType", required = false) ClubType clubType, // 연합동아리, 교내동아리
+            @RequestParam(value = "fieldType", required = false) Category category) { // 동아리 분류
+        return recruitService.findAll(pageNum, sortType, clubType, category);
+    }
 }

--- a/src/main/java/com/cluting/clutingbackend/recruit/domain/Recruit.java
+++ b/src/main/java/com/cluting/clutingbackend/recruit/domain/Recruit.java
@@ -4,6 +4,7 @@ import com.cluting.clutingbackend.club.domain.Club;
 import com.cluting.clutingbackend.global.enums.CurrentStage;
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
 
 import java.time.LocalDateTime;
 
@@ -37,6 +38,10 @@ public class Recruit {
 
     @Column(length = 255, nullable = true)
     private String caution; // 공고 질문 관련 주의 사항
+
+    @Column(nullable = true)
+    @CreatedDate
+    private LocalDateTime createdAt; // 생성 시간
 
     @Column(nullable = true)
     private LocalDateTime deadLine; // 마감기한

--- a/src/main/java/com/cluting/clutingbackend/recruit/dto/request/RecruitCriteriaSaveRequestDto.java
+++ b/src/main/java/com/cluting/clutingbackend/recruit/dto/request/RecruitCriteriaSaveRequestDto.java
@@ -1,0 +1,25 @@
+package com.cluting.clutingbackend.recruit.dto.request;
+
+import com.cluting.clutingbackend.plan.domain.DocumentCriteria;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RecruitCriteriaSaveRequestDto {
+    private String criteria;
+    private List<String> detailCriteria;
+    private Integer score;
+
+    public DocumentCriteria toEntity() {
+        return DocumentCriteria.builder()
+                .name(criteria)
+                .content((detailCriteria != null) ? String.join(":::", detailCriteria) : "")
+                .score(score)
+                .build();
+    }
+}

--- a/src/main/java/com/cluting/clutingbackend/recruit/dto/request/RecruitDocSetRequestDto.java
+++ b/src/main/java/com/cluting/clutingbackend/recruit/dto/request/RecruitDocSetRequestDto.java
@@ -1,0 +1,14 @@
+package com.cluting.clutingbackend.recruit.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RecruitDocSetRequestDto {
+    private List<RecruitRoleAllocateRequestDto> groups;
+}

--- a/src/main/java/com/cluting/clutingbackend/recruit/dto/request/RecruitRoleAllocateRequestDto.java
+++ b/src/main/java/com/cluting/clutingbackend/recruit/dto/request/RecruitRoleAllocateRequestDto.java
@@ -1,0 +1,17 @@
+package com.cluting.clutingbackend.recruit.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RecruitRoleAllocateRequestDto {
+    private String groupName;
+    private List<Long> admins;
+    private List<RecruitCriteriaSaveRequestDto> criteria;
+    private Integer maxScore;
+}

--- a/src/main/java/com/cluting/clutingbackend/recruit/dto/response/RecruitDocPrepSavedResponseDto.java
+++ b/src/main/java/com/cluting/clutingbackend/recruit/dto/response/RecruitDocPrepSavedResponseDto.java
@@ -1,0 +1,9 @@
+package com.cluting.clutingbackend.recruit.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class RecruitDocPrepSavedResponseDto {
+}

--- a/src/main/java/com/cluting/clutingbackend/recruit/dto/response/RecruitNumResponseDto.java
+++ b/src/main/java/com/cluting/clutingbackend/recruit/dto/response/RecruitNumResponseDto.java
@@ -1,0 +1,15 @@
+package com.cluting.clutingbackend.recruit.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class RecruitNumResponseDto {
+    private Integer num;
+    private Map<String, Integer> map;
+}

--- a/src/main/java/com/cluting/clutingbackend/recruit/dto/response/RecruitResponseDto.java
+++ b/src/main/java/com/cluting/clutingbackend/recruit/dto/response/RecruitResponseDto.java
@@ -1,0 +1,41 @@
+package com.cluting.clutingbackend.recruit.dto.response;
+
+import com.cluting.clutingbackend.global.enums.Category;
+import com.cluting.clutingbackend.global.enums.ClubType;
+import com.cluting.clutingbackend.recruit.domain.Recruit;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class RecruitResponseDto {
+    private Long id;
+    private Long clubId;
+    private String title;
+    private String description;
+    private Category category;
+    private ClubType clubType;
+    private String profile;
+    private Boolean isDone;
+    private String caution;
+    private LocalDateTime deadLine;
+    private LocalDateTime createdAt;
+
+    public static RecruitResponseDto toDto(Recruit entity) {
+        return RecruitResponseDto.builder()
+                .id(entity.getId())
+                .clubId(entity.getClub().getId())
+                .title(entity.getTitle())
+                .description(entity.getDescription())
+                .clubType(entity.getClub().getType())
+                .category(entity.getClub().getCategory())
+                .profile(entity.getImage())
+                .isDone(entity.getIsDone())
+                .caution(entity.getCaution())
+                .deadLine(entity.getDeadLine())
+                .createdAt(entity.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/cluting/clutingbackend/recruit/dto/response/RecruitsResponseDto.java
+++ b/src/main/java/com/cluting/clutingbackend/recruit/dto/response/RecruitsResponseDto.java
@@ -1,0 +1,15 @@
+package com.cluting.clutingbackend.recruit.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class RecruitsResponseDto {
+    private Integer count;
+    private List<RecruitResponseDto> recruits;
+}

--- a/src/main/java/com/cluting/clutingbackend/recruit/service/RecruitService.java
+++ b/src/main/java/com/cluting/clutingbackend/recruit/service/RecruitService.java
@@ -1,23 +1,37 @@
 package com.cluting.clutingbackend.recruit.service;
 
+import com.cluting.clutingbackend.application.domain.Application;
+import com.cluting.clutingbackend.application.repository.ApplicationRepository;
+import com.cluting.clutingbackend.clubuser.domain.ClubUser;
+import com.cluting.clutingbackend.clubuser.repository.ClubUserRepository;
 import com.cluting.clutingbackend.global.enums.Category;
 import com.cluting.clutingbackend.global.enums.ClubType;
 import com.cluting.clutingbackend.global.enums.SortType;
+import com.cluting.clutingbackend.global.enums.Stage;
 import com.cluting.clutingbackend.global.util.StaticValue;
+import com.cluting.clutingbackend.plan.domain.DocumentEvaluator;
 import com.cluting.clutingbackend.plan.domain.Group;
+import com.cluting.clutingbackend.plan.repository.DocumentCriteriaRepository;
+import com.cluting.clutingbackend.plan.repository.DocumentEvaluatorRepository;
 import com.cluting.clutingbackend.plan.repository.GroupRepository;
 import com.cluting.clutingbackend.recruit.domain.Recruit;
+import com.cluting.clutingbackend.recruit.dto.request.RecruitCriteriaSaveRequestDto;
+import com.cluting.clutingbackend.recruit.dto.request.RecruitDocSetRequestDto;
+import com.cluting.clutingbackend.recruit.dto.request.RecruitRoleAllocateRequestDto;
+import com.cluting.clutingbackend.recruit.dto.response.RecruitDocPrepSavedResponseDto;
 import com.cluting.clutingbackend.recruit.dto.response.RecruitNumResponseDto;
 import com.cluting.clutingbackend.recruit.dto.response.RecruitResponseDto;
 import com.cluting.clutingbackend.recruit.dto.response.RecruitsResponseDto;
 import com.cluting.clutingbackend.recruit.repository.RecruitRepository;
-import com.cluting.clutingbackend.recruit.repository.RecruitScheduleRepository;
+import com.cluting.clutingbackend.user.domain.User;
+import com.cluting.clutingbackend.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -27,7 +41,11 @@ import java.util.Map;
 public class RecruitService {
     private final RecruitRepository recruitRepository;
     private final GroupRepository groupRepository;
-    private final RecruitScheduleRepository recruitScheduleRepository;
+    private final ClubUserRepository clubUserRepository;
+    private final ApplicationRepository applicationRepository;
+    private final DocumentCriteriaRepository documentCriteriaRepository;
+    private final DocumentEvaluatorRepository documentEvaluatorRepository;
+    private final UserRepository userRepository;
 
     @Transactional(readOnly = true)
     public RecruitsResponseDto findAll(Integer pageNum, SortType sortType, ClubType clubType, Category category) {
@@ -98,8 +116,99 @@ public class RecruitService {
         return new RecruitNumResponseDto(totalNum, groupMap);
     }
 
-    //TODO 서류 평가 준비하기 설정 (공통 그룹 처리 필요)
     @Transactional
-    public void setDocEvaluate() {
+    public RecruitDocPrepSavedResponseDto saveDocRecruit(Long recruitId, RecruitDocSetRequestDto recruitDocSetRequestDto) {
+        Recruit recruit = recruitRepository.findById(recruitId)
+                .orElseThrow(
+                        () -> new ResponseStatusException(
+                                HttpStatus.BAD_REQUEST, "존재하지 않는 리크루팅 입니다."
+                        )
+                );
+        List<Group> groups                       = groupRepository.findByRecruit_Id(recruitId);
+        List<Application> applications           = applicationRepository.findByRecruit_Id(recruitId);
+        Map<String, Group> groupMap                = new HashMap<>();
+        Map<String, Application> applicationMap  = new HashMap<>();
+        for (Group group : groups) groupMap.put(group.getName(), group);
+        for (Application application : applications) applicationMap.put(application.getPart(), application);
+
+        // 공통일 경우에는 그룹 추가 (그룹이 추가된 경우)
+        // 모집공고에 대한 그룹이 한 개이며, (그룹 이름이 null 이거나 공통이고), requestDto 에 입력된 그룹의 개수가 1개 초과일 경우(= 그룹 추가가 이뤄진 경우)
+        Group firstGroup = groups.get(0);
+        if (groups.size() == 1 && (firstGroup.getName() == null || firstGroup.getName().equals("공통")) && recruitDocSetRequestDto.getGroups().size() > 1) {
+            int groupCount = recruitDocSetRequestDto.getGroups().size();
+            int numRecruit = firstGroup.getNumRecruit();
+            int divNum = numRecruit / groupCount;
+            int modNum = numRecruit % groupCount;
+            for (int i = 0; i < groupCount; i++) {
+                if (i == 0) {
+                    firstGroup.setName(recruitDocSetRequestDto.getGroups().get(i).getGroupName());
+                    firstGroup.setNumRecruit(divNum);
+                    if(modNum > 0) firstGroup.setNumRecruit(divNum + 1);
+                    modNum--;
+                    groupRepository.save(firstGroup);
+                }
+                int newRecruitNum = divNum;
+                if(modNum > 0) {
+                    newRecruitNum++;
+                    modNum--;
+                }
+                String newGroupName = recruitDocSetRequestDto.getGroups().get(i).getGroupName();
+                groupRepository.save(Group.of(firstGroup.getRecruit(), newGroupName, firstGroup.getNumDoc(), firstGroup.getNumFinal(), newRecruitNum, firstGroup.getWarning()));
+            }
+
+            // 새로운 데이터셋
+            groups = groupRepository.findByRecruit_Id(recruitId);
+            groupMap.clear();
+            for (Group group : groups) groupMap.put(group.getName(), group);
+        }
+
+        // 서류 평가 기준 저장
+        for (RecruitRoleAllocateRequestDto dto : recruitDocSetRequestDto.getGroups()) {
+            dto.getCriteria().forEach(documentCriteriaRepository.save(RecruitCriteriaSaveRequestDto::toEntity));
+        }
+
+        // 서류 평가 중간 테이블 저장
+        for (RecruitRoleAllocateRequestDto dto : recruitDocSetRequestDto.getGroups()) {
+            Group group = groupMap.get(dto.getGroupName());
+            if (group == null) throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "존재하지 않는 그룹입니다.");
+
+            int numRecruit = group.getNumRecruit();
+            int count = 0;
+
+            // 그룹에 할당된 ClubUser(admins 리스트)
+            List<Long> adminIds = dto.getAdmins();
+            List<ClubUser> clubUsers = new ArrayList<>();
+            for (Long adminId : adminIds) {
+                ClubUser clubUser = getClubUser(adminId);
+                clubUsers.add(clubUser);
+            }
+
+            // 각 Application에 대해 DocumentEvaluator 생성
+            for (Application application : applications) {
+                if (count >= numRecruit) break;
+                ClubUser assignedClubUser = clubUsers.get(count % clubUsers.size());
+                DocumentEvaluator evaluator = DocumentEvaluator.of(
+                        assignedClubUser,
+                        application,
+                        group,
+                        Stage.BEFORE,
+                        null,
+                        null
+                );
+                documentEvaluatorRepository.save(evaluator);
+                count++;
+            }
+        }
+
+        return RecruitDocPrepSavedResponseDto.builder().build(); //TODO
+    }
+
+    public ClubUser getClubUser(Long clubUserId) {
+        return clubUserRepository.findById(clubUserId)
+                .orElseThrow(
+                        () -> new ResponseStatusException(
+                                HttpStatus.BAD_REQUEST, "존재하지 않는 운영진 입니다."
+                        )
+                );
     }
 }

--- a/src/main/java/com/cluting/clutingbackend/recruit/service/RecruitService.java
+++ b/src/main/java/com/cluting/clutingbackend/recruit/service/RecruitService.java
@@ -4,14 +4,17 @@ import com.cluting.clutingbackend.global.enums.Category;
 import com.cluting.clutingbackend.global.enums.ClubType;
 import com.cluting.clutingbackend.global.enums.SortType;
 import com.cluting.clutingbackend.global.util.StaticValue;
+import com.cluting.clutingbackend.recruit.domain.Recruit;
 import com.cluting.clutingbackend.recruit.dto.response.RecruitResponseDto;
 import com.cluting.clutingbackend.recruit.dto.response.RecruitsResponseDto;
 import com.cluting.clutingbackend.recruit.repository.RecruitRepository;
 import com.cluting.clutingbackend.recruit.repository.RecruitScheduleRepository;
 import com.cluting.clutingbackend.user.domain.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 
@@ -44,5 +47,17 @@ public class RecruitService {
                 .toList();
 
         return new RecruitsResponseDto(recruitDtos.size(), recruitDtos);
+    }
+
+    @Transactional(readOnly = true)
+    public RecruitResponseDto findById(Long recruitId) {
+        Recruit recruit = recruitRepository.findById(recruitId)
+                .orElseThrow(
+                        () -> new ResponseStatusException(
+                                HttpStatus.BAD_REQUEST, "존재하지 않는 리크루팅 입니다."
+                        )
+                );
+
+        return RecruitResponseDto.toDto(recruit);
     }
 }

--- a/src/main/java/com/cluting/clutingbackend/recruit/service/RecruitService.java
+++ b/src/main/java/com/cluting/clutingbackend/recruit/service/RecruitService.java
@@ -1,13 +1,48 @@
 package com.cluting.clutingbackend.recruit.service;
 
+import com.cluting.clutingbackend.global.enums.Category;
+import com.cluting.clutingbackend.global.enums.ClubType;
+import com.cluting.clutingbackend.global.enums.SortType;
+import com.cluting.clutingbackend.global.util.StaticValue;
+import com.cluting.clutingbackend.recruit.dto.response.RecruitResponseDto;
+import com.cluting.clutingbackend.recruit.dto.response.RecruitsResponseDto;
 import com.cluting.clutingbackend.recruit.repository.RecruitRepository;
 import com.cluting.clutingbackend.recruit.repository.RecruitScheduleRepository;
+import com.cluting.clutingbackend.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class RecruitService {
     private final RecruitRepository recruitRepository;
     private final RecruitScheduleRepository recruitScheduleRepository;
+
+    @Transactional(readOnly = true)
+    public RecruitsResponseDto findAll(Integer pageNum, SortType sortType, ClubType clubType, Category category) {
+        int pageSize = StaticValue.PAGE_DEFAULT_SIZE;
+        int skipCount = (pageNum - 1) * pageSize;
+
+        List<RecruitResponseDto> recruitDtos = recruitRepository.findAll().stream()
+                .map(RecruitResponseDto::toDto)
+                .filter(dto -> clubType == null || dto.getClubType() == clubType)
+                .filter(dto -> category == null || dto.getCategory() == category)
+                .sorted((dto1, dto2) -> {
+                    if (sortType == null) return 0;
+                    return switch (sortType) {
+                        case DEADLINE -> dto1.getDeadLine().compareTo(dto2.getDeadLine());
+                        case NEWEST -> dto2.getCreatedAt().compareTo(dto1.getCreatedAt());
+                        case OLDEST -> dto1.getCreatedAt().compareTo(dto2.getCreatedAt());
+                        default -> 0;
+                    };
+                })
+                .skip(skipCount)
+                .limit(pageSize)
+                .toList();
+
+        return new RecruitsResponseDto(recruitDtos.size(), recruitDtos);
+    }
 }

--- a/src/main/java/com/cluting/clutingbackend/recruit/service/RecruitService.java
+++ b/src/main/java/com/cluting/clutingbackend/recruit/service/RecruitService.java
@@ -4,24 +4,29 @@ import com.cluting.clutingbackend.global.enums.Category;
 import com.cluting.clutingbackend.global.enums.ClubType;
 import com.cluting.clutingbackend.global.enums.SortType;
 import com.cluting.clutingbackend.global.util.StaticValue;
+import com.cluting.clutingbackend.plan.domain.Group;
+import com.cluting.clutingbackend.plan.repository.GroupRepository;
 import com.cluting.clutingbackend.recruit.domain.Recruit;
+import com.cluting.clutingbackend.recruit.dto.response.RecruitNumResponseDto;
 import com.cluting.clutingbackend.recruit.dto.response.RecruitResponseDto;
 import com.cluting.clutingbackend.recruit.dto.response.RecruitsResponseDto;
 import com.cluting.clutingbackend.recruit.repository.RecruitRepository;
 import com.cluting.clutingbackend.recruit.repository.RecruitScheduleRepository;
-import com.cluting.clutingbackend.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
 public class RecruitService {
     private final RecruitRepository recruitRepository;
+    private final GroupRepository groupRepository;
     private final RecruitScheduleRepository recruitScheduleRepository;
 
     @Transactional(readOnly = true)
@@ -59,5 +64,42 @@ public class RecruitService {
                 );
 
         return RecruitResponseDto.toDto(recruit);
+    }
+
+    @Transactional(readOnly = true)
+    public RecruitNumResponseDto findAppliedNum(Long recruitId) {
+        Map<String, Integer> groupMap = new HashMap<>();
+        List<Group> groups = groupRepository.findByRecruit_Id(recruitId);
+        int totalNum = 0;
+        for (Group group : groups) {
+            totalNum += group.getNumRecruit();
+            String groupName = group.getName();
+            if (groupName != null) {
+                groupMap.put(groupName, group.getNumRecruit());
+            }
+        }
+
+        return new RecruitNumResponseDto(totalNum, groupMap);
+    }
+
+    @Transactional(readOnly = true)
+    public RecruitNumResponseDto findDocPassNum(Long recruitId) {
+        Map<String, Integer> groupMap = new HashMap<>();
+        List<Group> groups = groupRepository.findByRecruit_Id(recruitId);
+        int totalNum = 0;
+        for (Group group : groups) {
+            totalNum += group.getNumRecruit();
+            String groupName = group.getName();
+            if (groupName != null) {
+                groupMap.put(groupName, group.getNumDoc());
+            }
+        }
+
+        return new RecruitNumResponseDto(totalNum, groupMap);
+    }
+
+    //TODO 서류 평가 준비하기 설정 (공통 그룹 처리 필요)
+    @Transactional
+    public void setDocEvaluate() {
     }
 }

--- a/src/main/java/com/cluting/clutingbackend/user/dto/request/UserSignUpRequestDto.java
+++ b/src/main/java/com/cluting/clutingbackend/user/dto/request/UserSignUpRequestDto.java
@@ -5,12 +5,14 @@ import com.cluting.clutingbackend.global.enums.Role;
 import com.cluting.clutingbackend.global.enums.Semester;
 import com.cluting.clutingbackend.global.enums.StudentStatus;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
 public class UserSignUpRequestDto {
     private String name;
     private String email;
     private String password;
+    @Setter
     private String phone;
     private String location;
     private String school;

--- a/src/main/java/com/cluting/clutingbackend/user/service/UserService.java
+++ b/src/main/java/com/cluting/clutingbackend/user/service/UserService.java
@@ -40,6 +40,7 @@ public class UserService {
                     );
                 });
 
+        userSignUpRequestDto.setPhone(userSignUpRequestDto.getPhone().replaceAll("-", ""));
         User user = userRepository.save(
                 userSignUpRequestDto.toEntity(passwordEncoder.encode(userSignUpRequestDto.getPassword()))
         );


### PR DESCRIPTION
## 📝작업 내용

### 완료한 기능
- [x] [홈화면] 로그인 사용자의 동아리 조회
- [x] [홈화면] 전체 모집 공고 조회
- [x] [홈화면] 동아리 단일 조회
- [x] [홈화면] 모집 공고 단일 조회
- [x] [서류 평가하기] 서류 지원자 수 조회
- [x] [서류 평가하기] 서류 합격 예정자 수 조회
- [x] [서류 평가하기] 동아리의 운영진 목록 조회
- [x] [서류 평가하기] 서류 평가 준비하기 설정 저장

### 수정한 도메인
- [x] ERD에서 서류평가기준 테이블에 최대점수 maxScore 추가
- [x] DocumentCriteria의 content에 Lob 추가 (직렬, 역직렬화)

## 💬리뷰 요구사항(선택)

[com.cluting.clutingbackend.recruit.service] 경로의 마지막 메서드인 saveDocRecruit 한 번 검토 부탁드립니다
